### PR TITLE
mHLaSDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Higher-Order LaSDI
 
-Higher-Order LaSDI provides tools for building reduced-order models (ROMs) from full-order simulations using latent-space dynamics identification with Gaussian Process-based greedy sampling. The library supports physics that require multiple time derivatives (e.g., displacement and velocity for second-order systems) and handles time series with either uniform or non-uniform time grids. Latent dynamics models such as SINDy and damped-spring systems are provided, and new EncoderDecoders can be added easily.
+Higher-Order LaSDI provides tools for building reduced-order models (ROMs) from full-order (FOM) simulations using latent-space dynamics identification with Gaussian Process-based greedy sampling. Higher-Order LaSDI is designed to be incredibly flexible. At its core, a reduced-order model (ROM) consists of:
+1. A parameterized collection of time series that live in some high-dimensional, FOM space (Physics).
+2. An Encoder/Decoder pair which can map elements from the FOM space to a lower dimensional latent space (EncoderDecoder).
+3. A parameterized set of latent dynamics to describe how the encodings of a particular time series evolves (LatentDynamics).
+4. A procedure to learn an encoder/decoder/latent dynamics given training data (Trainer).
+5. A method to greedily pick new training elements (Sampler).
+Higher-Order LaSDI implements a modular framework that allows the user to customize each one of these steps. Each one has an associated base class (specified by parentheses in the list) which defines the interface the rest of the code uses when interacting with that portion of the workflow. The library includes a few subclasses for each step, but you can customize any of them by defining a subclass of the corresponding base class. As long as the subclass interface matches what the library expects, it should integrate cleanly. Want to embed a domain-specific inductive bias into the latent dynamics? Define a `LatentDynamics` subclass. Need an EncoderDecoder structure tailored to your data? Define an `EncoderDecoder` subclass. Want to use a custom physics-inspired loss? Implement it in a `Physics` subclass. Higher-Order LaSDI is designed to be flexible, extensible, and modular.
 
 ## Key Features
 
@@ -8,10 +14,10 @@ Higher-Order LaSDI provides tools for building reduced-order models (ROMs) from 
 - **Higher-Order Dynamics**: Native support for systems requiring multiple time derivatives
 - **Flexible Time Grids**: Handles both uniform and non-uniform temporal discretizations with automatic finite difference scheme selection
 - **Multiple Loss Functions**: Reconstruction, latent dynamics, rollout, IC rollout, chain rule, and consistency losses with configurable weights
-- **Autoencoder Architectures**: Standard autoencoder and paired autoencoder for higher-order systems
+- **EncoderDecoder Architectures**: Standard autoencoder, paired autoencoder for higher-order systems
 - **Rich Activation Functions**: Support for 20+ activation functions including sine, ReLU, tanh, GELU, and more
 - **Visualization Tools**: Automated plotting of latent trajectories, error heatmaps, and solution animations
-- **Training stability & diagnostics**: Gradient clipping (config: `trainer.gradient_clip`) to prevent exploding gradients, and per-parameter loss logging to `results/*_loss_by_param.pkl` for post-hoc analysis
+- **Training stability & diagnostics**: Gradient clipping (typically configured under `trainer.<TrainerType>.gradient_clip`) to prevent exploding gradients, and per-parameter loss logging to `results/*_loss_by_param.pkl` for post-hoc analysis
 
 ## Getting Started
 
@@ -46,7 +52,7 @@ The `examples/` directory contains configuration files for various physics probl
 | Example | Physics Type | Order | Grid Type |
 |---------|-------------|-------|-----------|
 | `Explicit.yml` | Custom explicit solver | 1st | Uniform |
-| `Burgers.yml` | Burgers equation | 1st | Uniform |
+| `Burgers.yml` | Burgers equation (second-order formulation) | 2nd | Uniform |
 | `Burgers2D.yml` | 2D Burgers equation | 1st | Uniform |
 | `Thermal.yml` | Thermal diffusion (HDF5) | 1st | Uniform |
 | `Advection.yml` | Advection equation (PyMFEM) | 1st | Uniform |
@@ -59,18 +65,50 @@ The `examples/` directory contains configuration files for various physics probl
 
 ## Repository Layout
 
+### EncoderDecoders and $n_{IC}$
+
+Higher-Order LaSDI supports higher-order latent dynamics (via multiple time derivatives) and multi-stage training (via multiple decoders).
+
+The key hyperparameters for an `EncoderDecoder` are:
+- $n_{IC}$: the number of initial-condition components used by the latent dynamics. Practically, this means we treat the training data as a tuple containing the FOM frame and its first $n_{IC}-1$ time derivatives:
+  \[
+    \left(u,\ \dot{u},\ \ddot{u},\ \ldots,\ u^{(n_{IC}-1)}\right).
+  \]
+- $n_z$ (sometimes written $n_{latent}$): latent-space dimension, so each latent component lives in $\mathbb{R}^{n_z}$.
+- $n_{Decoders}$: number of decoder *stages* used to enable multi-stage training (mLaSDI-style).
+
+**Interface.** An `EncoderDecoder` is a `torch.nn.Module` with the following core methods:
+- `Encode(*Xs) -> tuple[torch.Tensor, ...]`  
+  Takes `n_IC` tensors `Xs = (X0, X1, ..., X_{n_IC-1})` (the FOM frame and its derivatives) and returns `n_IC` latent tensors `Zs = (Z0, Z1, ..., Z_{n_IC-1})`, each typically shaped `(batch, n_z)`.
+- `Eval_Decoder(i_Decoder, *Zs) -> tuple[torch.Tensor, ...]`  
+  Evaluates the *i-th* decoder stage on the latent tuple, returning a tuple of `n_IC` decoded tensors in FOM space.
+- `Decode(*Zs)` (implemented in the base class)  
+  Produces the decoded tuple by taking a **weighted sum** over the active decoder stages. Concretely, for each component index `j`:
+  \[
+    X_j \;=\; \sum_{d\ \text{active}} w_{j,d}\, \mathrm{Eval\_Decoder}(d, Z_0,\ldots,Z_{n_{IC}-1})_j.
+  \]
+  The weights $w_{j,d}$ live in `Decoder_Weight[j, d]`, and which decoders participate is controlled by `Decoder_Active[d]`. These settings are included in `export()`/`load()` so multi-stage state can be checkpointed and restored.
+
+If you set `n_Decoders = 1` (the default/common case), this reduces to the original single-decoder behavior: `Decode(*Zs)` is exactly `Eval_Decoder(0, *Zs)` (up to the default unit weight).
+
+In general, every Physics, EncoderDecoder, and Trainer object expects a specific $n_{IC}$ value. These must match for the code to work. Thus, for instance, if your Physics sub-class defines time series consisting of some time series and its first time derivative, then $n_{IC} = 2$ and you must select a Trainer and LatentDynamics model that also use $n_{IC} = 2$. 
+
 ### Core Components
 
 - **`src/Workflow.py`** – Main command-line driver that loads configuration files, initializes components, and runs the training pipeline
-- **`src/Trainer/Trainer.py`** – Base `Trainer` class: normalization helpers, checkpointing, loss logging, timing, and round-based training orchestration
-- **`src/Trainer/Rollout_1_IC.py`** – `Trainer` subclass for first-order systems (`n_IC = 1`): reconstruction + latent-dynamics + rollout losses
-- **`src/Trainer/Rollout_2_IC.py`** – `Trainer` subclass for second-order systems (`n_IC = 2`): paired-derivative training (includes chain rule + consistency losses)
-- **`src/Initialize.py`** – Factory functions for initializing trainers, EncoderDecoders, physics solvers, and latent dynamics from config files
+- **`src/Trainer/`** - The class which defines how the encoder/decoder/latent dynamics train using the available data
+    - `Trainer.py` – Base `Trainer` class: normalization helpers, checkpointing, loss logging, timing, and round-based training orchestration
+    - `First_Order_Rollout.py` – `Trainer` subclass for first-order systems (`n_IC = 1`)
+    - `Second_Order_Rollout.py` – `Trainer` subclass for second-order systems (`n_IC = 2`)
+    - `Second_Order_Noise.py` – Similar to `Second_Order_Rollout` but can add noise to the data
+    - `Second_Order_Noise_Weak.py` – Similar to `Second_Order_Noise`, but intended for weak-form latent dynamics
+- **`src/Initialize.py`** – Factory functions for initializing trainers, EncoderDecoders, physics solvers, and latent dynamics from config files. You must register all new sub-classes in this file.
 - **`src/EncoderDecoder`** – Neural network architectures:
   - `EncoderDecoder.py`: Base `EncoderDecoder` class.
   - `MLP.py`: Flexible MLP with customizable activations
   - `Autoencoder.py`: Standard autoencoder for first-order systems
   - `Autoencoder_Pair.py`: Paired autoencoder for higher-order systems (encodes multiple derivatives)
+  - `CNN_3D_Autoencoder.py`: 3D convolutional autoencoder variant
 - **`src/ParameterSpace.py`** – Parameter space management, grid generation, and train/test split utilities
 - **`src/SolveROMs.py`** – ROM simulation functions:
   - `average_rom()`: Simulate using GP mean predictions
@@ -143,14 +181,14 @@ The `examples/` directory contains configuration files for various physics probl
 Configuration files are YAML-based and specify:
 
 ### Trainer Settings (`trainer`)
-- `trainer.type` selects the concrete `Trainer` subclass to use (e.g., `Rollout_1_IC`, `Rollout_2_IC`).
+- `trainer.type` selects the concrete `Trainer` subclass to use (e.g., `First_Order_Rollout`, `Second_Order_Rollout`, `Second_Order_Noise`, `Second_Order_Noise_Weak`).
 - Round scheduling / greedy sampling limits:
   - `trainer.n_iter`, `trainer.max_iter`, `trainer.max_greedy_iter`
 - Normalization:
   - `trainer.normalize` (if enabled, the library computes global mean/std and normalizes train/test data)
 - Device placement:
   - `trainer.device` (optional; `"cpu"` by default)
-- Subclass-specific settings live under `trainer.<TypeName>`. Example (`Rollout_2_IC`):
+- Subclass-specific settings live under `trainer.<TypeName>`. Example (`Second_Order_Rollout`):
   - learning rate + stability: `lr`, `gradient_clip`, `warmup_epochs`
   - rollout curriculum: `p_rollout_init`, `rollout_update_freq`, `dp_per_update`, `max_p_rollout`
   - rollout sampling: `n_rollouts`
@@ -174,10 +212,11 @@ Configuration files are YAML-based and specify:
 - Test space configuration (grid, random, or file-based)
 
 ### EncoderDecoder Architecture (`EncoderDecoder`)
-- EncoderDecoder type: `ae` (Autoencoder), `pair` (Autoencoder_Pair), or `3d CNN` (CNN_3D).
+- EncoderDecoder type: `ae`/`autoencoder` (Autoencoder), `pair`/`autoencoder_pair` (Autoencoder_Pair), or `cnn_3d`/`cnn_3d_ae`/`cnn_3d_autoencoder` (CNN_3D_Autoencoder).
 - Hidden layer widths
 - Activation functions
 - Latent dimension
+- Number of decoder stages: `n_Decoders`
 
 ### Latent Dynamics (`latent_dynamics`)
 - Type: `sindy`, `spring`, or `switch sindy`.
@@ -202,7 +241,7 @@ Create a new file under `src/Trainer/`, for example `src/Trainer/MyTrainer.py`, 
 - `__init__(physics, encoder_decoder, latent_dynamics, param_space, config)`
 - `Iterate(start_iter, end_iter)` (the actual per-epoch training logic)
 
-Follow the existing trainers (`Rollout_1_IC`, `Rollout_2_IC`) as templates. In particular, your
+Follow the existing trainers (`First_Order_Rollout`, `Second_Order_Rollout`, `Second_Order_Noise`, `Second_Order_Noise_Weak`) as templates. In particular, your
 `Iterate(...)` method should:
 
 - Log losses via `_store_loss_by_param(...)` / `_store_total_loss(...)`
@@ -222,8 +261,10 @@ from MyTrainer import MyTrainer
 
 ```python
 trainer_dict = {
-    'Rollout_1_IC': Rollout_1_IC,
-    'Rollout_2_IC': Rollout_2_IC,
+    'First_Order_Rollout'      : First_Order_Rollout,
+    'Second_Order_Rollout'     : Second_Order_Rollout,
+    'Second_Order_Noise'       : Second_Order_Noise,
+    'Second_Order_Noise_Weak'  : Second_Order_Noise_Weak,
     'MyTrainer'  : MyTrainer,
 }
 ```
@@ -258,7 +299,7 @@ Tested with the following versions:
 - scipy (1.14.1)
 - matplotlib (3.9.2)
 
-These pacakages are listed in the "requirements.txt" file
+These packages are listed in the `requirements.txt` file.
 
 
 ### Installing with venv (recommended)
@@ -312,7 +353,7 @@ deactivate
 - Install via your system package manager/module (e.g., `apt-get install ffmpeg`, `brew install ffmpeg`, or `module load ffmpeg`)
 
 **For HDF5 data loading (Thermal example):**
-- hdf5 (the system HDF5 library, not a python pacakage; 1.14.5)
+- hdf5 (the system HDF5 library, not a Python package; 1.14.5)
 - h5py (3.14.0)
 
 **For PyMFEM examples:**
@@ -644,13 +685,29 @@ parameter point(s) to add to the training set after each training round.
 
 ### Adding a New EncoderDecoder Architecture
 
-1. **Create a subclass** of `EncoderDecoder` which should be placed in a file in `src/EncoderDecoder`
-2. **Implement required methods**:
-   - `Encode(self, X(1), ... , X(n_IC))`: Encode full-order state to latent space
-   - `Decode(self, Z(1), ... , Z(n_IC))`: Decode latent state to full-order space
-   - `forward(self, X(1), ... , X(n_IC))`: Encode and then Decode the FOM states.
-   - `export()`: Returns a dictionary that can be used to serialize the EncoderDecoder.
-3. **Register in `Initialize.py`**:
+1. **Create a subclass** of `EncoderDecoder` in `src/EncoderDecoder/YourEncoderDecoder.py`.
+2. **Implement the required interface** (minimal set):
+   - `__init__(self, Frame_Shape: list[int], config: dict)`:
+     - Parse `config['type']` and your type-specific sub-config.
+     - Call `super().__init__(n_IC=..., n_z=..., n_Decoders=..., config=config)`.
+     - Construct the encoder module(s) and the per-stage decoder module(s) (e.g., a `torch.nn.ModuleList` of length `n_Decoders`).
+   - `Encode(self, *Xs) -> tuple[torch.Tensor, ...]`:
+     - Accept `n_IC` FOM tensors (frame + derivatives) and return `n_IC` latent tensors.
+   - `Eval_Decoder(self, i_Decoder: int, *Zs) -> tuple[torch.Tensor, ...]`:
+     - Run the requested decoder stage `i_Decoder` and return `n_IC` decoded tensors in FOM space.
+   - `export(self) -> dict`:
+     - Return a dict that includes `super().export()` (so `Decoder_Active`/`Decoder_Weight` are checkpointed) plus your module state dicts and any architecture metadata needed to reconstruct the model.
+   - A corresponding `load_YourEncoderDecoder(dict_) -> YourEncoderDecoder` free function:
+     - Instantiate the model (using saved `Frame_Shape`/`config`/architecture metadata),
+     - call `model.load(dict_['EncoderDecoder dict'])` to restore `Decoder_Active`/`Decoder_Weight`,
+     - load module parameters from state dicts.
+
+3. **Optional overrides** (only if you need custom behavior):
+   - `Decode(self, *Zs)` if you want a non-linear combination of decoder stages (the base class implements a weighted sum over active stages).
+   - `forward(self, *Xs)` (the base class calls `Encode` then `Decode`).
+   - `latent_initial_conditions(...)` if you need custom IC handling (the base class provides a default implementation).
+   - `Set_Decoder_Active` / `Set_Decoder_Weight` if you want custom validation or semantics.
+4. **Register in `Initialize.py`**:
    ```python
    encoder_decoder_dict = {
        ...
@@ -661,7 +718,9 @@ parameter point(s) to add to the training set after each training round.
        'your_encoder_decoder': load_YourEncoderDecoder,
    }
    ```
-4. **Define how to train your architecture**: Import your new EncoderDecoder sub-class in `Trainer.py`. Either add the new class to one of the existing cases (using the pre-selected loss functions) in the `Trainer` class' `train` method, or define a new case to handle your new class.
+5. **Define how to train your architecture**:
+   - If your model follows the standard `Encode` / `Decode` contract (and your losses don’t rely on architecture-specific internals), you may be able to reuse an existing trainer (e.g., `First_Order_Rollout` or `Second_Order_Rollout`).
+   - If you need architecture-specific losses or training logic, implement a new `Trainer` subclass and register it in `trainer_dict` in `src/Initialize.py`.
 
 
 ## Testing and Development
@@ -684,11 +743,11 @@ Training produces several outputs:
 
 ### Gradient clipping
 
-To prevent exploding gradients during training, `Trainer` applies global gradient-norm clipping via `torch.nn.utils.clip_grad_norm_` (threshold: `trainer.gradient_clip`, default: `15.0`). When clipping activates, a warning is logged.
+To prevent exploding gradients during training, Trainer subclasses apply global gradient-norm clipping via `torch.nn.utils.clip_grad_norm_`. The threshold is typically configured under `trainer.<TrainerType>.gradient_clip` (default varies by trainer; see the corresponding trainer subclass). When clipping activates, a warning is logged.
 
 ### Per-parameter loss logging (`*_loss_by_param.pkl`)
 
-During training, `src/Trainer.py` writes a pickle file:
+During training, the trainer writes a pickle file (see `src/Trainer/Trainer.py`):
 
 - Path: `results/<physics_type>_loss_by_param.pkl` (where `<physics_type>` is `config['physics']['type']`)
 - Type: nested Python dictionaries

--- a/examples/Advection.yml
+++ b/examples/Advection.yml
@@ -73,6 +73,7 @@ parameter_space:
 EncoderDecoder:
   type:                     autoencoder
   autoencoder:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       10  
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/Burgers.yml
+++ b/examples/Burgers.yml
@@ -73,10 +73,12 @@ parameter_space:
 EncoderDecoder:
   type:                     pair
   autoencoder:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       5  
     activations:            ["sin", "sin", "sin", "sin"]
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       5
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/Burgers.yml
+++ b/examples/Burgers.yml
@@ -1,9 +1,9 @@
 trainer:
   type:                   "Second_Order_Rollout"
 
-  max_iter:               20000
-  n_iter:                 2500
-  max_greedy_iter:        20000
+  max_iter:               5000
+  n_iter:                 30000
+  max_greedy_iter:        0
   
   # If true, compute a single global mean/std from TRAINING data only, and normalize
   # all training/testing trajectories using these values.
@@ -34,17 +34,17 @@ trainer:
       chain_rule:           1.0
       LD:                   1.0
       rollout:              0.0
-      IC_rollout:           0.2
+      IC_rollout:           0.0
       coef:                 0.0001
       consistency:          1.0
 
     loss_types:
-      recon:                "MAE"
-      chain_rule:           "MAE"
-      LD:                   "MAE"
-      rollout:              "MAE"
-      IC_rollout:           "MAE"
-      consistency:          "MAE"
+      recon:                "MSE"
+      chain_rule:           "MSE"
+      LD:                   "MSE"
+      rollout:              "MSE"
+      IC_rollout:           "MSE"
+      consistency:          "MSE"
 
 workflow:
   use_restart:              false

--- a/examples/Burgers2D.yml
+++ b/examples/Burgers2D.yml
@@ -69,6 +69,7 @@ parameter_space:
 EncoderDecoder:
   type:                     autoencoder
   autoencoder:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       5  
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/Burgers_noise.yml
+++ b/examples/Burgers_noise.yml
@@ -1,69 +1,46 @@
-# ==================================================================================================
-# Burgers Second-Order — Weak Form with Noisy Training Data
-# ==================================================================================================
-#
-# This config is identical to Burgers_w.yml except for noise-related changes:
-#
-#   1.  noise_ratio: 0.05  — adds Gaussian noise to training data (sigma = ratio * signal_rms).
-#       Test data is kept clean so that evaluation compares predictions against noise-free truth.
-#       The first frame (IC) of every training trajectory is preserved (perfect IC assumption).
-#
-#   2.  consistency and chain_rule losses are KEPT ACTIVE because the weak form
-#       (type: spring_w) automatically switches to noise-tolerant variants that
-#       use integration-by-parts instead of finite differences.
-#
-#       NOTE: If you disable the weak form (type: spring), you should set
-#       consistency: 0.0 and chain_rule: 0.0 since the strong-form FD versions
-#       amplify noise catastrophically.
-#
-#   3.  lstsq_reg: 1.0e-3  — mild Tikhonov regularization for the weak-form LS solve to
-#       stabilize coefficient estimation under noise.
-#
-# The weak-form LD loss (Phi-integrated) is inherently noise-tolerant: integration against
-# compactly-supported test functions acts as a smoother, so the LD loss remains reliable.
-#
-# Reconstruction loss trains against noisy data, but the ODE solver in latent space produces
-# smooth rollouts, so predictions are compared against clean test data at evaluation time.
-# ==================================================================================================
-
 trainer:
-  type:                   "Second_Order_Noise_Weak"
+  type:                   "Second_Order_Noise"
 
   max_iter:               5000
+  # n_iter:                 2500
+  # max_greedy_iter:        20000
   n_iter:                 30000
   max_greedy_iter:        0
-
+  
+  # If true, compute a single global mean/std from TRAINING data only, and normalize
+  # all training/testing trajectories using these values.
   normalize:              false
+
   device:                 'cpu'
 
-  Second_Order_Noise_Weak:
+  Second_Order_Noise:
     lr:                     0.001
-    gradient_clip:          50.0
+    gradient_clip:          50.0      # Maximum allowable gradient magnitude; will rescale gradients if exceeded.
 
-    # Ratio of noise std to signal RMS.  Set to 0.0 to recover noise-free behaviour.
-    noise_ratio:            0.05
-
+    # p_rollout grows from p_rollout_init by dp_per_update every rollout_update_freq epochs, capped at max_p_rollout.
     p_rollout_init:         0.01
     rollout_update_freq:    20
     dp_per_update:          0.01
-    max_p_rollout:          0.75
-    n_rollouts:             4
+    max_p_rollout:          0.75      # Maximum proportion of the time window used for rollout loss.
+    n_rollouts:             4         # Number of rollable start frames to rollout per training parameter per epoch.
+
+    noise_ratio:            0.05
 
     p_IC_rollout_init:      0.01
     IC_rollout_update_freq: 20
     IC_dp_per_update:       0.01
-    max_p_IC_rollout:       1.0
+    max_p_IC_rollout:       1.0       # Maximum proportion of the time window used for IC rollout loss.
 
-    warmup_epochs:          20
+    warmup_epochs:          20    # Number of epochs to warmup the learning rate after greedy sampling; checkpointing is disabled during warmup.
 
     loss_weights:
       recon:                1.0
-      chain_rule:           1.0       # Weak-form variant: Phi @ V_FOM + dPhi @ D_pred ≈ 0 (no JVP, no FD).
+      chain_rule:           1.0
       LD:                   1.0
       rollout:              0.0
       IC_rollout:           0.0
       coef:                 0.0001
-      consistency:          1.0       # Weak-form variant: dPhi @ Z_D + Phi @ Z_V ≈ 0 (no FD).
+      consistency:          1.0
 
     loss_types:
       recon:                "MSE"
@@ -81,7 +58,7 @@ workflow:
 sampler:
   type:                   'FOM_Variance'
   FOM_Variance:
-    n_samples:            20
+    n_samples:            20        # Number of samples used to compute rollout stds.   
 
 parameter_space:
   parameters:
@@ -101,19 +78,33 @@ EncoderDecoder:
   type:                     pair
   autoencoder:
     hidden_widths:          [250, 100, 100, 100]
-    latent_dimension:       5
+    latent_dimension:       5  
     activations:            ["sin", "sin", "sin", "sin"]
   pair:
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       5
     activations:            ["sin", "sin", "sin", "sin"]
 
+# EncoderDecoder:
+#   type:                     pair
+#   pair:
+#     hidden_widths:          [100, 50]
+#     latent_dimension:       5
+#     activations:            ["softplus", "softplus"]
+
+# latent_dynamics:
+#   type:                     spring
+#   lstsq_reg:                1.0           # Ridge-regression regularization for SINDy coefficient initialization (prevents blow-up for new greedy-sampled points).
+#   spring:
+
+  sindy:
 latent_dynamics:
+  # type:                     spring
   type:                     spring_w
   lstsq_reg:                0.0
   spring_w:
     test_func:              'PC-poly'
-    test_func_width:        .1
+    test_func_width:        .1 #50/(nt - 1) is a good default
     overlap:                0.8
     pq:                     8
     LS_loss_type:           'weak'

--- a/examples/Burgers_noise.yml
+++ b/examples/Burgers_noise.yml
@@ -76,11 +76,8 @@ parameter_space:
 
 EncoderDecoder:
   type:                     pair
-  autoencoder:
-    hidden_widths:          [250, 100, 100, 100]
-    latent_dimension:       5  
-    activations:            ["sin", "sin", "sin", "sin"]
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       5
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/Burgers_noise_weak.yml
+++ b/examples/Burgers_noise_weak.yml
@@ -1,45 +1,70 @@
+# ==================================================================================================
+# Burgers Second-Order — Weak Form with Noisy Training Data
+# ==================================================================================================
+#
+# This config is identical to Burgers_w.yml except for noise-related changes:
+#
+#   1.  noise_ratio: 0.05  — adds Gaussian noise to training data (sigma = ratio * signal_rms).
+#       Test data is kept clean so that evaluation compares predictions against noise-free truth.
+#       The first frame (IC) of every training trajectory is preserved (perfect IC assumption).
+#
+#   2.  consistency and chain_rule losses are KEPT ACTIVE because the weak form
+#       (type: spring_w) automatically switches to noise-tolerant variants that
+#       use integration-by-parts instead of finite differences.
+#
+#       NOTE: If you disable the weak form (type: spring), you should set
+#       consistency: 0.0 and chain_rule: 0.0 since the strong-form FD versions
+#       amplify noise catastrophically.
+#
+#   3.  lstsq_reg: 1.0e-3  — mild Tikhonov regularization for the weak-form LS solve to
+#       stabilize coefficient estimation under noise.
+#
+# The weak-form LD loss (Phi-integrated) is inherently noise-tolerant: integration against
+# compactly-supported test functions acts as a smoother, so the LD loss remains reliable.
+#
+# Reconstruction loss trains against noisy data, but the ODE solver in latent space produces
+# smooth rollouts, so predictions are compared against clean test data at evaluation time.
+# ==================================================================================================
+
 trainer:
   type:                   "Second_Order_Noise_Weak"
 
   max_iter:               5000
-  # n_iter:                 2500
-  # max_greedy_iter:        20000
   n_iter:                 30000
   max_greedy_iter:        0
-  
-  # If true, compute a single global mean/std from TRAINING data only, and normalize
-  # all training/testing trajectories using these values.
-  normalize:              false
 
+  normalize:              false
   device:                 'cpu'
 
   Second_Order_Noise_Weak:
     lr:                     0.001
-    gradient_clip:          50.0      # Maximum allowable gradient magnitude; will rescale gradients if exceeded.
+    gradient_clip:          50.0
 
-    # p_rollout grows from p_rollout_init by dp_per_update every rollout_update_freq epochs, capped at max_p_rollout.
+    # Ratio of noise std to signal RMS.  Set to 0.0 to recover noise-free behaviour.
+    noise_ratio:            0.05
+    
+
     p_rollout_init:         0.01
     rollout_update_freq:    20
     dp_per_update:          0.01
-    max_p_rollout:          0.75      # Maximum proportion of the time window used for rollout loss.
-    n_rollouts:             4         # Number of rollable start frames to rollout per training parameter per epoch.
+    max_p_rollout:          0.75
+    n_rollouts:             4
 
     p_IC_rollout_init:      0.01
     IC_rollout_update_freq: 20
     IC_dp_per_update:       0.01
-    max_p_IC_rollout:       1.0       # Maximum proportion of the time window used for IC rollout loss.
+    max_p_IC_rollout:       1.0
 
-    warmup_epochs:          20    # Number of epochs to warmup the learning rate after greedy sampling; checkpointing is disabled during warmup.
+    warmup_epochs:          20
 
     loss_weights:
       recon:                1.0
-      chain_rule:           1.0
+      chain_rule:           1.0       # Weak-form variant: Phi @ V_FOM + dPhi @ D_pred ≈ 0 (no JVP, no FD).
       LD:                   1.0
       rollout:              0.0
-      # IC_rollout:           0.2
       IC_rollout:           0.0
       coef:                 0.0001
-      consistency:          1.0
+      consistency:          1.0       # Weak-form variant: dPhi @ Z_D + Phi @ Z_V ≈ 0 (no FD).
 
     loss_types:
       recon:                "MSE"
@@ -57,7 +82,7 @@ workflow:
 sampler:
   type:                   'FOM_Variance'
   FOM_Variance:
-    n_samples:            20        # Number of samples used to compute rollout stds.   
+    n_samples:            20
 
 parameter_space:
   parameters:
@@ -77,33 +102,19 @@ EncoderDecoder:
   type:                     pair
   autoencoder:
     hidden_widths:          [250, 100, 100, 100]
-    latent_dimension:       5  
+    latent_dimension:       5
     activations:            ["sin", "sin", "sin", "sin"]
   pair:
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       5
     activations:            ["sin", "sin", "sin", "sin"]
 
-# EncoderDecoder:
-#   type:                     pair
-#   pair:
-#     hidden_widths:          [100, 50]
-#     latent_dimension:       5
-#     activations:            ["softplus", "softplus"]
-
-# latent_dynamics:
-#   type:                     spring
-#   lstsq_reg:                1.0           # Ridge-regression regularization for SINDy coefficient initialization (prevents blow-up for new greedy-sampled points).
-#   spring:
-
-  sindy:
 latent_dynamics:
-  # type:                     spring
   type:                     spring_w
   lstsq_reg:                0.0
   spring_w:
     test_func:              'PC-poly'
-    test_func_width:        .1 #50/(nt - 1) is a good default
+    test_func_width:        .1
     overlap:                0.8
     pq:                     8
     LS_loss_type:           'weak'

--- a/examples/Burgers_noise_weak.yml
+++ b/examples/Burgers_noise_weak.yml
@@ -100,11 +100,8 @@ parameter_space:
 
 EncoderDecoder:
   type:                     pair
-  autoencoder:
-    hidden_widths:          [250, 100, 100, 100]
-    latent_dimension:       5
-    activations:            ["sin", "sin", "sin", "sin"]
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       5
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/Explicit.yml
+++ b/examples/Explicit.yml
@@ -69,10 +69,12 @@ parameter_space:
 EncoderDecoder:
   type:                     ae
   ae:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     activations:            ["sin", "sin", "sin", "sin"]
     latent_dimension:       10
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       10 
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/KleinGordon.yml
+++ b/examples/KleinGordon.yml
@@ -76,6 +76,7 @@ parameter_space:
 EncoderDecoder:
   type:                     pair
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       10 
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/NonlinearElasticity.yml
+++ b/examples/NonlinearElasticity.yml
@@ -76,6 +76,7 @@ parameter_space:
 EncoderDecoder:
   type:                     pair
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       10
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/Telegraphers.yml
+++ b/examples/Telegraphers.yml
@@ -1,9 +1,9 @@
 trainer:
   type:                   "Second_Order_Rollout"
 
-  max_iter:               36000
+  max_iter:               18000
   n_iter:                 6000
-  max_greedy_iter:        36000
+  max_greedy_iter:        18000
 
   # If true, compute a single global mean/std from TRAINING data only, and normalize
   # all training/testing trajectories using these values.
@@ -13,21 +13,21 @@ trainer:
 
   Second_Order_Rollout:
     lr:                     0.001
-    gradient_clip:          15.0      # Maximum allowable gradient magnitude; will rescale gradients if exceeded.
+    gradient_clip:          15.0        # Maximum allowable gradient magnitude; will rescale gradients if exceeded.
 
     # p_rollout grows from p_rollout_init by dp_per_update every rollout_update_freq epochs, capped at max_p_rollout.
     p_rollout_init:         0.01
     rollout_update_freq:    20
     dp_per_update:          0.01
-    max_p_rollout:          0.75      # Maximum proportion of the time window used for rollout loss.
-    n_rollouts:             4         # Number of rollable start frames to rollout per training parameter per epoch.
+    max_p_rollout:          0.25        # Maximum proportion of the time window used for rollout loss.
+    n_rollouts:             12          # Number of rollable start frames to rollout per training parameter per epoch.
 
     p_IC_rollout_init:      0.01
     IC_rollout_update_freq: 20
     IC_dp_per_update:       0.01
-    max_p_IC_rollout:       1.0       # Maximum proportion of the time window used for IC rollout loss.
+    max_p_IC_rollout:       1.0         # Maximum proportion of the time window used for IC rollout loss.
 
-    warmup_epochs:          20    # Number of epochs to warmup the learning rate after greedy sampling; checkpointing is disabled during warmup.
+    warmup_epochs:          40          # Number of epochs to warmup the learning rate after greedy sampling; checkpointing is disabled during warmup.
 
     loss_weights:
       recon:                1.0
@@ -36,6 +36,7 @@ trainer:
       rollout:              1.0
       IC_rollout:           1.0
       coef:                 0.001
+      stab:                 0.1
       consistency:          1.0
 
     loss_types:
@@ -76,6 +77,7 @@ parameter_space:
 EncoderDecoder:
   type:                     pair
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       10
     activations:            ["sin", "sin", "sin", "sin"]

--- a/examples/Thermal.yml
+++ b/examples/Thermal.yml
@@ -1,9 +1,9 @@
 trainer:
   type:                   "First_Order_Rollout"
 
-  max_iter:               6000
+  max_iter:               3000
   n_iter:                 1500
-  max_greedy_iter:        6000
+  max_greedy_iter:        3000
 
   # If true, compute a single global mean/std from TRAINING data only, and normalize
   # all training/testing trajectories using these values.
@@ -13,19 +13,19 @@ trainer:
 
   First_Order_Rollout:       
     lr:                     0.001
-    gradient_clip:          10.0      # Maximum allowable gradient magnitude; will rescale gradients if exceeded.
+    gradient_clip:          10.0        # Maximum allowable gradient magnitude; will rescale gradients if exceeded.
 
     # p_rollout grows from p_rollout_init by dp_per_update every rollout_update_freq epochs, capped at max_p_rollout.
     p_rollout_init:         0.01
     rollout_update_freq:    10
     dp_per_update:          0.005
-    max_p_rollout:          0.375       # Maximum proportion of the time window used for rollout loss.
-    n_rollouts:             13          # Frame-rollout mode: number of rollable start frames to rollout per training parameter per epoch.
+    max_p_rollout:          0.25        # Maximum proportion of the time window used for rollout loss.
+    n_rollouts:             12          # Frame-rollout mode: number of rollable start frames to rollout per training parameter per epoch.
 
     p_IC_rollout_init:      0.01
     IC_rollout_update_freq: 10
-    IC_dp_per_update:       0.0075
-    max_p_IC_rollout:       0.75      # Maximum proportion of the time window used for IC rollout loss.
+    IC_dp_per_update:       0.01
+    max_p_IC_rollout:       1.0       # Maximum proportion of the time window used for IC rollout loss.
 
     warmup_epochs:          40        # Number of epochs to warmup the learning rate after greedy sampling; checkpointing is disabled during warmup.
 
@@ -33,9 +33,9 @@ trainer:
       recon:                1.0
       LD:                   10.0
       rollout:              1.0
-      IC_rollout:           0.0
+      IC_rollout:           0.1
       stab:                 0.01
-      coef:                 1.0
+      coef:                 2.0
 
     loss_types:
       recon:                "MSE"
@@ -69,6 +69,8 @@ parameter_space:
 EncoderDecoder:
   type:                     cnn_3d
   cnn_3d:
+    n_Decoders:             1
+
     # Fully-connected (FC) part
     hidden_widths_fc:       [500, 100]
     activations_fc:         ["tanh", "tanh"]

--- a/examples/WaveEquation.yml
+++ b/examples/WaveEquation.yml
@@ -76,6 +76,7 @@ parameter_space:
 EncoderDecoder:
   type:                     pair
   pair:
+    n_Decoders:             1
     hidden_widths:          [250, 100, 100, 100]
     latent_dimension:       10
     activations:            ["sin", "sin", "sin", "sin"]

--- a/src/EncoderDecoder/Autoencoder.py
+++ b/src/EncoderDecoder/Autoencoder.py
@@ -38,11 +38,15 @@ class Autoencoder(EncoderDecoder):
                     config          : dict) -> None:
         r"""
         Initializes an Autoencoder object. An Autoencoder consists of two networks, an encoder, 
-        E : \mathbb{R}^F -> \mathbb{R}^L, and a decoder, D : \mathbb{R}^L -> \marthbb{R}^F. We 
-        assume that the dataset consists of samples of a parameterized L-manifold in 
+        E : \mathbb{R}^F -> \mathbb{R}^L, and a Decoder, D : \mathbb{R}^L -> \marthbb{R}^F. 
+
+        We assume that the dataset consists of samples of a parameterized L-manifold in 
         \mathbb{R}^F. The idea then is that E and D act like the inverse coordinate patch and 
-        coordinate patch, respectively. In our case, E and D are trainable neural networks. We 
-        try to train E and map data in \mathbb{R}^F to elements of a low dimensional latent 
+        coordinate patch, respectively. In our case, E is a neural network, and D is a linear 
+        combination of sub-decoders (to allow for multi-stage training), each one of which is a 
+        Neural Network.
+        
+        We try to train E and map data in \mathbb{R}^F to elements of a low dimensional latent 
         space (\mathbb{R}^L) which D can send back to the original data. (thus, E, and D should
         act like inverses of one another).
 
@@ -91,10 +95,10 @@ class Autoencoder(EncoderDecoder):
         assert "activations"        in ae_config;
         assert "n_Decoders"         in ae_config;
         
-        assert isinstance(Frame_Shape, list),                 "type(Frame_Shape) == %s, expected list" % (str(type(reshape_shape)));
+        assert isinstance(Frame_Shape, list),                 "type(Frame_Shape) == %s, expected list" % (str(type(Frame_Shape)));
         for i in range(len(Frame_Shape)):
-            assert isinstance(Frame_Shape[i], int),           "type(Frame_Shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
-            assert Frame_Shape[i] > 0,                        "Frame_Shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
+            assert isinstance(Frame_Shape[i], int),           "type(Frame_Shape[%d]) = %s, expected int" % (i, str(type(Frame_Shape[i])));
+            assert Frame_Shape[i] > 0,                        "Frame_Shape[%d] = %d, needs to be positive" % (i, Frame_Shape[i]);
         
 
 
@@ -124,7 +128,7 @@ class Autoencoder(EncoderDecoder):
         for i in range(len(widths)):
             assert isinstance(widths[i], int),                  "type(widths[%d]) = %s, must be int" % (i, str(type(widths[i])));
             assert widths[i] > 0,                               "widths[%d] = %d, must be positive" % (i, widths[i]);
-        assert numpy.prod(Frame_Shape) == widths[0],            "numpy.prod(self.reshape_shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(reshape_shape), widths[0]);
+        assert numpy.prod(Frame_Shape) == widths[0],            "numpy.prod(self.Frame_Shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(Frame_Shape), widths[0]);
 
         # Extract the number of decoders.
         n_Decoders = config[ae_key]['n_Decoders'];
@@ -135,7 +139,7 @@ class Autoencoder(EncoderDecoder):
         # Store information (for return purposes).
         self.widths         : list[int] = widths;
         self.activations    : list[str] = activations;
-        self.reframe_shape  : list[int] = Frame_Shape;
+        self.Frame_Shape    : list[int] = Frame_Shape;
         LOGGER.info("Initializing an Autoencoder with latent space dimension %d" % self.n_z);
         LOGGER.info("  Reshape shape: %s" % str(Frame_Shape));
         LOGGER.info("  Widths: %s" % str(widths));
@@ -151,7 +155,7 @@ class Autoencoder(EncoderDecoder):
                             reshape_shape       = Frame_Shape);
 
         LOGGER.info("Initializing the decoder...");
-        self.decoders = torch.nn.ModuleList;
+        self.decoders = torch.nn.ModuleList([]);
         for i in range(n_Decoders):
             self.decoders.append(MultiLayerPerceptron(
                                     widths              = widths[::-1],         # Reverses the order for the decoder.
@@ -173,7 +177,7 @@ class Autoencoder(EncoderDecoder):
         Arguments
         -------------------------------------------------------------------------------------------
 
-        X : torch.Tensor, shape = (n_Frames,) + self.reshape_shape
+        X : torch.Tensor, shape = (n_Frames,) + self.Frame_Shape
             X[i, ...] holds the i'th frame we want to encode. 
 
 
@@ -188,8 +192,8 @@ class Autoencoder(EncoderDecoder):
 
         # Check that the inputs have the correct shape.
         assert isinstance(U, torch.Tensor),                             "type(U) = %s, must be torch.Tensor" % type(U);
-        assert len(U.shape)         ==  len(self.reshape_shape) + 1,    "U.shape = %s, self.reshape_shape = %s"     % (str(U.shape), str(self.reshape_shape));
-        assert list(U.shape[1:])    ==  self.reshape_shape,             "U.shape[1:] = %s, self.reshape_shape = %s" % (str(U.shape[1:]), str(self.reshape_shape));
+        assert len(U.shape)         ==  len(self.Frame_Shape) + 1,    "U.shape = %s, self.Frame_Shape = %s"     % (str(U.shape), str(self.Frame_Shape));
+        assert list(U.shape[1:])    ==  self.Frame_Shape,             "U.shape[1:] = %s, self.Frame_Shape = %s" % (str(U.shape[1:]), str(self.Frame_Shape));
     
         # Encode the frames!
         return (self.encoder(U),);
@@ -218,17 +222,17 @@ class Autoencoder(EncoderDecoder):
 
         R : tuple[torch.Tensor], len = 1
             A single element tuple whose lone element is a torch.Tensor with shape = (n_Frames,) 
-            + self.reshape_shape. R[i ...] represents the reconstruction of the i'th FOM frame.
+            + self.Frame_Shape. R[i ...] represents the reconstruction of the i'th FOM frame.
         """
 
         # Checks 
         assert len(Z.shape)   == 2,                                     "Z.shape = %s, must have length 2." % str(Z.shape);
-        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders),      "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
 
         # Decode the frames!
         # NOTE: Return a tuple for consistency with the EncoderDecoder interface and with
         # Autoencoder.Encode(...), which returns a 1-tuple.
-        return (self.decoder[i_Decoder](Z),);
+        return (self.decoders[i_Decoder](Z),);
 
 
 
@@ -240,7 +244,7 @@ class Autoencoder(EncoderDecoder):
 
         This function extracts everything we need to recreate self from scratch. Specifically, we 
         extract the encoder/decoder state dictionaries, self's architecture, activation function 
-        and reshape_shape. We store and return this information in a dictionary.
+        and Frame_Shape. We store and return this information in a dictionary.
          
         You can pass the returned dictionary to the load_Autoencoder method to generate an 
         Autoencoder object that is identical to self.
@@ -251,14 +255,15 @@ class Autoencoder(EncoderDecoder):
 
         decoder_states_list = [];
         for i in range(self.n_Decoders):
-            decoder_states_list.append(self.decoder[i].cpu().state_dict());
+            decoder_states_list.append(self.decoders[i].cpu().state_dict());
 
-        dict_ = {   'encoder_state'  : self.encoder.cpu().state_dict(),
-                    'decoder_states' : decoder_states_list,
-                    'widths'         : self.widths, 
-                    'activations'    : self.activations, 
-                    'reshape_shape'  : self.reshape_shape,
-                    'config'         : self.config};
+        dict_ = {   'EncoderDecoder dict'   : super().export(),
+                    'encoder_state'         : self.encoder.cpu().state_dict(),
+                    'decoder_states'        : decoder_states_list,
+                    'widths'                : self.widths, 
+                    'activations'           : self.activations, 
+                    'Frame_Shape'           : self.Frame_Shape,
+                    'config'                : self.config};
         return dict_;
 
 
@@ -291,11 +296,14 @@ def load_Autoencoder(dict_ : dict) -> Autoencoder:
 
     # First, extract the parameters we need to initialize an Autoencoder object with the same 
     # architecture as the one that created dict_.
-    reshape_shape   : list[int] = dict_['reshape_shape'];
+    Frame_Shape     : list[int] = dict_['Frame_Shape'];
     config          : dict      = dict_['config'];
 
     # Now... initialize an Autoencoder object.
-    AE = Autoencoder(reshape_shape = reshape_shape, config = config);
+    AE = Autoencoder(Frame_Shape = Frame_Shape, config = config);
+
+    # Set the Decoder_Weights, Active.
+    AE.load(dict_ = dict_['EncoderDecoder dict']);
 
     # Now, update the encoder/decoder parameters.
     AE.encoder.load_state_dict(dict_['encoder_state']); 
@@ -303,7 +311,7 @@ def load_Autoencoder(dict_ : dict) -> Autoencoder:
     decoder_states  : list  = dict_['decoder_states'];
     n_Decoders      : int   = len(decoder_states);
     for i in range(n_Decoders):
-        AE.decoder[i].load_state_dict(decoder_states[i]); 
+        AE.decoders[i].load_state_dict(decoder_states[i]); 
 
     # All done, AE is now identical to the Autoencoder object that created dict_.
     return AE;

--- a/src/EncoderDecoder/Autoencoder.py
+++ b/src/EncoderDecoder/Autoencoder.py
@@ -33,10 +33,9 @@ LOGGER  : logging.Logger    = logging.getLogger(__name__);
 # -------------------------------------------------------------------------------------------------
 
 class Autoencoder(EncoderDecoder):
-    def __init__(   self,                     
-                    reshape_shape   : list[int],
-                    widths          : list[int], 
-                    activations     : list[str]) -> None:
+    def __init__(   self,         
+                    Frame_Shape     : list[int],    
+                    config          : dict) -> None:
         r"""
         Initializes an Autoencoder object. An Autoencoder consists of two networks, an encoder, 
         E : \mathbb{R}^F -> \mathbb{R}^L, and a decoder, D : \mathbb{R}^L -> \marthbb{R}^F. We 
@@ -53,21 +52,23 @@ class Autoencoder(EncoderDecoder):
         Arguments
         -------------------------------------------------------------------------------------------
         
-        reshape_shape : list[int]
-            This is a list of k integers specifying the final k dimensions of the shape of the 
-            input to the first layer (if reshape_index == 0) or the output of the last layer (if 
-            reshape_index == -1). 
+        Frame_Shape : list[int]
+            The shape of elements of the FOM space. This also specifies the final k dimensions of 
+            the shape of the input to the first layer (if reshape_index == 0) or the output of 
+            the last layer (if reshape_index == -1). 
         
-        widths : list[int]
-            A list of integers specifying the widths of the layers in the encoder. We use the 
-            revere of this list to specify the widths of the layers in the decoder. See the 
-            docstring for the MultiLayerPerceptron class for details on how Widths defines a 
-            network.
+        config: dict
+            The "EncoderDecoder" sub dictionary of the configuration file. This must contain 
+            a "type" key whose value is either "ae" or "autoencoder". It must also contain 
+            an item whose key matches the value of tye "type" key and whose value is a 
+            sub-dictionary specifying the configuration settings for the autoencoder object.
+            Namely, it must contain the following sub-keys:
+                - hidden_widths : A list of ints specifying the widths of the hidden layers
+                - latent_dimension : An integer specifying the latent dimension
+                - activations : A list of strings specifying the activation functions. It's 
+                length must match that of hidden_widths, and each element must belong to the act_dict.
+                - n_Decoders : an integer specifying the number of decoders we are to use.
 
-        activations : list[str], len = len(widths) - 2
-            i'th element specifies which activation function we want to use after the i'th layer 
-            in the encoder. The final layer has no activation function. We use the reversed list
-            for the decoder. 
 
 
 
@@ -77,32 +78,66 @@ class Autoencoder(EncoderDecoder):
 
         Nothing!
         """
+        
+        # Input checks.
+        assert 'type' in config;
+        assert (config['type'] == "ae") or (config['type'] == "autoencoder");
+        ae_key  : str = config['type'];
+        assert ae_key in config;
+        ae_config               : dict              = config[ae_key];
 
-        # Checks
-        assert isinstance(reshape_shape, list),             "type(reshape_shape) == %s, expected list" % (str(type(reshape_shape)));
-        for i in range(len(reshape_shape)):
-            assert isinstance(reshape_shape[i], int),           "type(reshape_shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
-            assert reshape_shape[i] > 0,                        "reshape_shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
-        assert isinstance(widths, list),                    "type(widths) = %s, expected list" % str(type(widths));
-        for i in range(len(widths)):
-            assert isinstance(widths[i], int),                  "type(widths[%d]) = %s, must be int" % (i, str(type(widths[i])));
-            assert widths[i] > 0,                               "widths[%d] = %d, must be positive" % (i, widths[i]);
-        assert isinstance(activations, list),               "type(activations) = %s, expected list" % str(type(activations));
-        assert len(activations) == len(widths) - 2,         "len(activations) = %d, len(widths) = %d; but we must have len(activations) = len(widths) - 2" % (len(activations), len(widths));
+        assert "hidden_widths"      in ae_config;
+        assert "latent_dimension"   in ae_config;
+        assert "activations"        in ae_config;
+        assert "n_Decoders"         in ae_config;
+        
+        assert isinstance(Frame_Shape, list),                 "type(Frame_Shape) == %s, expected list" % (str(type(reshape_shape)));
+        for i in range(len(Frame_Shape)):
+            assert isinstance(Frame_Shape[i], int),           "type(Frame_Shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
+            assert Frame_Shape[i] > 0,                        "Frame_Shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
+        
+
+
+        # Next, fetch the hidden widths and latent dimension (n_z). 
+        hidden_widths           : list[int]         = ae_config['hidden_widths'];
+        n_z                     : int               = ae_config['latent_dimension'];
+
+        # Fetch the activations. This can either be a string or a list of strings. If it's 
+        # a string, then we use that activation for all layers.
+        n_hidden_layers     : int               = len(hidden_widths);
+        if(isinstance(ae_config['activations'], str)):
+            activations         : list[str]     = [ae_config['activations']] * n_hidden_layers;   # The final layer has no activation.
+        elif(isinstance(ae_config['activations'], list)):
+            activations         : list[str]     = ae_config['activations'];
+            assert(len(activations) == n_hidden_layers);
+        else:
+            raise ValueError("Activations must be a string or a list of strings.");
+        
         for i in range(len(activations)):
             assert isinstance(activations[i], str),             "type(activations[%d]) = %s, must be str" % (i, str(type(activations[i])));
             assert activations[i].lower() in act_dict.keys(),   "activations[%d] = %s; not in act_dict keys" % (i, activations[i].lower());
-        assert numpy.prod(reshape_shape) == widths[0],      "numpy.prod(self.reshape_shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(reshape_shape), widths[0]);
+        
+
+        # Now build the widths attribute + fetch Frame_Shape from physics.
+        space_dim           : int               = numpy.prod(Frame_Shape).item();
+        widths              : list[int]         = [space_dim] + hidden_widths + [n_z];
+        for i in range(len(widths)):
+            assert isinstance(widths[i], int),                  "type(widths[%d]) = %s, must be int" % (i, str(type(widths[i])));
+            assert widths[i] > 0,                               "widths[%d] = %d, must be positive" % (i, widths[i]);
+        assert numpy.prod(Frame_Shape) == widths[0],            "numpy.prod(self.reshape_shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(reshape_shape), widths[0]);
+
+        # Extract the number of decoders.
+        n_Decoders = config[ae_key]['n_Decoders'];
 
         # Run the superclass initializer.
-        super().__init__(n_IC = 1, n_z = widths[-1]);
+        super().__init__(n_IC = 1, n_z = widths[-1], n_Decoders = n_Decoders, config = config);
         
         # Store information (for return purposes).
         self.widths         : list[int] = widths;
         self.activations    : list[str] = activations;
-        self.reshape_shape  : list[int] = reshape_shape;
+        self.reframe_shape  : list[int] = Frame_Shape;
         LOGGER.info("Initializing an Autoencoder with latent space dimension %d" % self.n_z);
-        LOGGER.info("  Reshape shape: %s" % str(reshape_shape));
+        LOGGER.info("  Reshape shape: %s" % str(Frame_Shape));
         LOGGER.info("  Widths: %s" % str(widths));
         LOGGER.info("  Activations: %s" % str(activations));
 
@@ -113,15 +148,16 @@ class Autoencoder(EncoderDecoder):
                             widths              = widths, 
                             activations         = activations,
                             reshape_index       = 0,                    # We need to flatten the spatial dimensions of each FOM frame.
-                            reshape_shape       = reshape_shape);
+                            reshape_shape       = Frame_Shape);
 
         LOGGER.info("Initializing the decoder...");
-        self.decoder = MultiLayerPerceptron(
-                            widths              = widths[::-1],         # Reverses the order for the decoder.
-                            activations         = activations[::-1],    # Reverses the order for the decoder.
-                            reshape_index       = -1,                   # We need to reshape the network output to a FOM frame.
-                            reshape_shape       = reshape_shape);       # We need to reshape the network output to a FOM frame.
-
+        self.decoders = torch.nn.ModuleList;
+        for i in range(n_Decoders):
+            self.decoders.append(MultiLayerPerceptron(
+                                    widths              = widths[::-1],         # Reverses the order for the decoder.
+                                    activations         = activations[::-1],    # Reverses the order for the decoder.
+                                    reshape_index       = -1,                   # We need to reshape the network output to a FOM frame.
+                                    reshape_shape       = Frame_Shape));      # We need to reshape the network output to a FOM frame.
 
         # All done!
         return;
@@ -160,7 +196,7 @@ class Autoencoder(EncoderDecoder):
 
 
 
-    def Decode(self, Z : torch.Tensor) -> tuple[torch.Tensor]:
+    def Eval_Decoder(self, i_Decoder : int, Z : torch.Tensor) -> tuple[torch.Tensor]:
         """
         This function decodes a set of latent frames.
 
@@ -169,6 +205,9 @@ class Autoencoder(EncoderDecoder):
         Arguments
         -------------------------------------------------------------------------------------------
 
+        i_Decoder : int
+            the index of the decoder we want to use to decode Z.
+        
         Z : torch.Tensor, shape = (n_Frames, self.n_z)
            i,j element holds the j'th component of the encoding of the i'th frame.
      
@@ -182,48 +221,14 @@ class Autoencoder(EncoderDecoder):
             + self.reshape_shape. R[i ...] represents the reconstruction of the i'th FOM frame.
         """
 
-        # Check that the input has the correct shape. 
-        assert len(Z.shape)   == 2, "Z.shape = %s, must have length 2." % str(Z.shape);
-    
+        # Checks 
+        assert len(Z.shape)   == 2,                                     "Z.shape = %s, must have length 2." % str(Z.shape);
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
+
         # Decode the frames!
         # NOTE: Return a tuple for consistency with the EncoderDecoder interface and with
         # Autoencoder.Encode(...), which returns a 1-tuple.
-        return (self.decoder(Z),);
-
-
-
-    def forward(self, X : torch.Tensor) -> tuple[torch.Tensor]:
-        """
-        This function passes X through the encoder, producing a latent state, Z. It then passes 
-        Z through the decoder; hopefully producing a vector that approximates X.
-        
-
-        -------------------------------------------------------------------------------------------
-        Arguments
-        -------------------------------------------------------------------------------------------
-
-        U : torch.Tensor, shape = (n_Frames,) + self.reshape_shape
-            A tensor holding a batch of inputs. We pass this tensor through the encoder + decoder 
-            and then return the result.
-
-
-        -------------------------------------------------------------------------------------------
-        Returns
-        -------------------------------------------------------------------------------------------
-
-        Y : tuple[torch.Tensor], len = 1
-            A single element tuple whose lone element is a torch.Tensor of shape = X.shape holding 
-            the image of X under the encoder and decoder. 
-        """
-
-        # Encoder the input
-        Z : torch.Tensor            = self.Encode(X)[0];
-
-        # Now decode z.
-        Y : tuple[torch.Tensor]     = self.Decode(Z);
-
-        # All done! Hopefully Y \approx X.
-        return Y;
+        return (self.decoder[i_Decoder](Z),);
 
 
 
@@ -244,11 +249,16 @@ class Autoencoder(EncoderDecoder):
         # TO DO: deep export which includes all information needed to re-initialize self from 
         # scratch. This would probably require changing the initializer.
 
-        dict_ = {   'encoder state'  : self.encoder.cpu().state_dict(),
-                    'decoder state'  : self.decoder.cpu().state_dict(),
+        decoder_states_list = [];
+        for i in range(self.n_Decoders):
+            decoder_states_list.append(self.decoder[i].cpu().state_dict());
+
+        dict_ = {   'encoder_state'  : self.encoder.cpu().state_dict(),
+                    'decoder_states' : decoder_states_list,
                     'widths'         : self.widths, 
                     'activations'    : self.activations, 
-                    'reshape_shape'  : self.reshape_shape};
+                    'reshape_shape'  : self.reshape_shape,
+                    'config'         : self.config};
         return dict_;
 
 
@@ -281,16 +291,19 @@ def load_Autoencoder(dict_ : dict) -> Autoencoder:
 
     # First, extract the parameters we need to initialize an Autoencoder object with the same 
     # architecture as the one that created dict_.
-    widths          : list[int] = dict_['widths'];
-    activations     : list[str] = dict_['activations'];
     reshape_shape   : list[int] = dict_['reshape_shape'];
+    config          : dict      = dict_['config'];
 
     # Now... initialize an Autoencoder object.
-    AE = Autoencoder(widths = widths, activations = activations, reshape_shape = reshape_shape);
+    AE = Autoencoder(reshape_shape = reshape_shape, config = config);
 
     # Now, update the encoder/decoder parameters.
-    AE.encoder.load_state_dict(dict_['encoder state']); 
-    AE.decoder.load_state_dict(dict_['decoder state']); 
+    AE.encoder.load_state_dict(dict_['encoder_state']); 
+
+    decoder_states  : list  = dict_['decoder_states'];
+    n_Decoders      : int   = len(decoder_states);
+    for i in range(n_Decoders):
+        AE.decoder[i].load_state_dict(decoder_states[i]); 
 
     # All done, AE is now identical to the Autoencoder object that created dict_.
     return AE;

--- a/src/EncoderDecoder/Autoencoder_Pair.py
+++ b/src/EncoderDecoder/Autoencoder_Pair.py
@@ -11,6 +11,7 @@ Physics_Path    : str   = os.path.abspath(os.path.join(os.path.dirname(__file__)
 sys.path.append(Physics_Path);
 
 import  logging;
+from    copy            import  deepcopy;
 
 import  torch;
 import  numpy;
@@ -40,9 +41,8 @@ class Autoencoder_Pair(EncoderDecoder):
     """
 
     def __init__(   self,
-                    reshape_shape       : list[int],
-                    widths              : list[int],
-                    activations         : list[str]) -> None:
+                    Frame_Shape         : list[int],
+                    config              : dict) -> None:
         """
         The initializer for the Autoencoder_Pair class. We assume that each input is a tuple 
         of data, (D, V), representing the displacement and velocity of some system at some point 
@@ -53,18 +53,25 @@ class Autoencoder_Pair(EncoderDecoder):
         Arguments
         -------------------------------------------------------------------------------------------
         
-        reshape_shape : list[int], len = k
-            specifies the final k dimensions of the shape of the input to the first layer (if 
-            reshape_index == 0) or the output of the last layer (if reshape_index == -1). 
+        Frame_shape : list[int], len = k
+            The shape of elements of the FOM space. This also specifies the final k dimensions of 
+            the shape of the input to the first layer (if reshape_index == 0) or the output of 
+            the last layer (if reshape_index == -1). 
 
-        widths : list[int]
-            specifies the widths of the layers in each encoder. See Autoencoder docstring.
-
-        activations : list[str], len = len(widths) - 2
-            i'th element specifies which activation function we want to use after the i'th layer 
-            in each encoder (decoder gets the reverse order). The final layer has no activation 
-            function. 
-    
+        config: dict
+            The "EncoderDecoder" sub dictionary of the configuration file. This must contain 
+            a "type" key whose value is either "pair" or "autoencoder_pair". It must also contain 
+            an item whose key matches the value of tye "type" key and whose value is a 
+            sub-dictionary specifying the configuration settings for the autoencoder_pair object.
+            Namely, it must contain the following sub-keys:
+                - hidden_widths : A list of ints specifying the widths of the hidden layers in 
+                each encoder
+                - latent_dimension : An integer specifying the latent dimension of each autoencoder
+                - activations : A list of strings specifying the activation functions for each 
+                encoder. It's length must match that of hidden_widths, and each element must belong
+                to the act_dict.
+                - n_Decoders : an integer specifying the number of decoders we are to use for each 
+                component of the solution.
             
         -------------------------------------------------------------------------------------------
         Returns
@@ -73,29 +80,63 @@ class Autoencoder_Pair(EncoderDecoder):
         Nothing!
         """
 
-        # Checks
-        assert isinstance(reshape_shape, list),             "type(reshape_shape) == %s, expected list" % (str(type(reshape_shape)));
-        for i in range(len(reshape_shape)):
-            assert isinstance(reshape_shape[i], int),           "type(reshape_shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
-            assert reshape_shape[i] > 0,                        "reshape_shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
-        assert isinstance(widths, list),                    "type(widths) = %s, expected list" % str(type(widths));
-        for i in range(len(widths)):
-            assert isinstance(widths[i], int),                  "type(widths[%d]) = %s, must be int" % (i, str(type(widths[i])));
-            assert widths[i] > 0,                               "widths[%d] = %d, must be positive" % (i, widths[i]);
-        assert isinstance(activations, list),               "type(activations) = %s, expected list" % str(type(activations));
-        assert len(activations) == len(widths) - 2,         "len(activations) = %d, len(widths) = %d; but we must have len(activations) = len(widths) - 2" % (len(activations), len(widths));
+        # Input checks.
+        assert 'type' in config;
+        assert (config['type'] == "pair") or (config['type'] == "autoencoder_pair");
+        pair_key  : str = config['type'];
+        assert pair_key in config;
+        pair_config             : dict              = config[pair_key];
+
+        assert "hidden_widths"      in pair_config;
+        assert "latent_dimension"   in pair_config;
+        assert "activations"        in pair_config;
+        assert "n_Decoders"         in pair_config;
+        
+        assert isinstance(Frame_Shape, list),                 "type(Frame_Shape) == %s, expected list" % (str(type(reshape_shape)));
+        for i in range(len(Frame_Shape)):
+            assert isinstance(Frame_Shape[i], int),           "type(Frame_Shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
+            assert Frame_Shape[i] > 0,                        "Frame_Shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
+        
+
+
+        # Next, fetch the hidden widths and latent dimension (n_z). 
+        hidden_widths           : list[int]         = pair_config['hidden_widths'];
+        n_z                     : int               = pair_config['latent_dimension'];
+
+        # Fetch the activations. This can either be a string or a list of strings. If it's 
+        # a string, then we use that activation for all layers.
+        n_hidden_layers     : int               = len(hidden_widths);
+        if(isinstance(pair_config['activations'], str)):
+            activations         : list[str]     = [pair_config['activations']] * n_hidden_layers;   # The final layer has no activation.
+        elif(isinstance(pair_config['activations'], list)):
+            activations         : list[str]     = pair_config['activations'];
+            assert(len(activations) == n_hidden_layers);
+        else:
+            raise ValueError("Activations must be a string or a list of strings.");
+        
         for i in range(len(activations)):
             assert isinstance(activations[i], str),             "type(activations[%d]) = %s, must be str" % (i, str(type(activations[i])));
             assert activations[i].lower() in act_dict.keys(),   "activations[%d] = %s; not in act_dict keys" % (i, activations[i].lower());
-        assert numpy.prod(reshape_shape) == widths[0],      "numpy.prod(self.reshape_shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(reshape_shape), widths[0]);
+        
 
-        # Call the super class initializer.
-        super().__init__(n_IC = 2, n_z = widths[-1]);
+        # Now build the widths attribute + fetch Frame_Shape from physics.
+        space_dim           : int               = numpy.prod(Frame_Shape).item();
+        widths              : list[int]         = [space_dim] + hidden_widths + [n_z];
+        for i in range(len(widths)):
+            assert isinstance(widths[i], int),                  "type(widths[%d]) = %s, must be int" % (i, str(type(widths[i])));
+            assert widths[i] > 0,                               "widths[%d] = %d, must be positive" % (i, widths[i]);
+        assert numpy.prod(Frame_Shape) == widths[0],            "numpy.prod(self.reshape_shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(reshape_shape), widths[0]);
+
+        # Extract the number of decoders.
+        n_Decoders = config[pair_key]['n_Decoders'];
+
+        # Run the superclass initializer.
+        super().__init__(n_IC = 2, n_z = widths[-1], n_Decoders = n_Decoders, config = config);
         LOGGER.info("Initializing an Autoencoder_Pair");
 
         # In general, the FOM solution may be vector valued and have multiple spatial dimensions. 
         # We need to know the shape of each FOM frame. 
-        self.reshape_shape  : list[int]     = reshape_shape; 
+        self.reshape_shape  : list[int]     = Frame_Shape; 
         
         # Fetch information about the domain/co-domain.
         self.widths         : list[int]     = widths;
@@ -103,16 +144,23 @@ class Autoencoder_Pair(EncoderDecoder):
         # Use the settings to set up the activation information for the encoder.
         self.activations    : list[str]     =  activations;
 
+        # Make a config for the AE.
+        ae_config = deepcopy(config);
+        ae_config['ae'] = deepcopy(config[pair_key]);
+        del ae_config[pair_key];
+
         # Next, build the velocity and displacement auto-encoders.
         LOGGER.info("Initializing the Displacement Autoencoder...");
         self.Displacement_Autoencoder   = Autoencoder(  widths          = widths, 
                                                         activations     = activations, 
-                                                        reshape_shape   = self.reshape_shape);
+                                                        reshape_shape   = self.reshape_shape,
+                                                        config          = ae_config);
 
         LOGGER.info("Initializing the Velocity Autoencoder...");
         self.Velocity_Autoencoder       = Autoencoder(  widths          = widths, 
                                                         activations     = activations,
-                                                        reshape_shape   = self.reshape_shape);
+                                                        reshape_shape   = self.reshape_shape,
+                                                        config          = ae_config);
 
 
 
@@ -169,9 +217,10 @@ class Autoencoder_Pair(EncoderDecoder):
 
 
 
-    def Decode(self,
-               Latent_Displacement  : torch.Tensor, 
-               Latent_Velocity      : torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def Eval_Decoder(   self,
+                        i_Decoder            : int, 
+                        Latent_Displacement  : torch.Tensor, 
+                        Latent_Velocity      : torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """
         This function decodes a set of displacement and velocity frames.
 
@@ -179,7 +228,10 @@ class Autoencoder_Pair(EncoderDecoder):
         -------------------------------------------------------------------------------------------
         Arguments
         -------------------------------------------------------------------------------------------
-
+        
+        i_Decoder : int
+            the index of the decoder we want to use to decode Z.
+        
         Latent_Displacement : torch.Tensor, shape = (N_Frames, self.n_z)
             i,j element represents the j'th component of the encoding of the displacement portion 
             of the i'th FOM frame.
@@ -204,71 +256,19 @@ class Autoencoder_Pair(EncoderDecoder):
             of i'th FOM frame.
         """
 
-        # Check that we have the same number of displacement, velocity frames.
+        # Checks
         assert isinstance(Latent_Displacement, torch.Tensor),   "type(Latent_Displacement) = %s; must be torch.Tensor" % str(type(Latent_Displacement));
         assert isinstance(Latent_Velocity, torch.Tensor),       "type(Latent_Velocity) = %s; must be torch.Tensor" % str(type(Latent_Velocity));
         assert len(Latent_Displacement.shape)   == 2,           "Latent_Displacement.shape = %s; must have length 2" % str(Latent_Displacement.shape);
         assert Latent_Velocity.shape            == Latent_Displacement.shape,   "Latent_Velocity.shape = %s, Latent_Displacement.shape = %s; must be equal" % (str(Latent_Displacement.shape), str(Latent_Velocity.shape));
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),          "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
 
         # Encode the displacement frames.
-        Reconstructed_Displacement  : torch.Tensor  = self.Displacement_Autoencoder.Decode( Latent_Displacement)[0];
-        Reconstructed_Velocity      : torch.Tensor  = self.Velocity_Autoencoder.Decode(     Latent_Velocity)[0];
+        Reconstructed_Displacement  : torch.Tensor  = self.Displacement_Autoencoder.Eval_Decoder( i_Decoder, Latent_Displacement)[0];
+        Reconstructed_Velocity      : torch.Tensor  = self.Velocity_Autoencoder.Eval_Decoder( i_Decoder, Latent_Velocity)[0];
 
         # All done!
         return Reconstructed_Displacement, Reconstructed_Velocity;
-
-
-
-    def forward(self, Displacement_Frames : torch.Tensor, Velocity_Frames : torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        The forward method for the Autoencoder_Pair class. It encodes and then decodes 
-        Displacement_Frames and Velocity_Frames.
-
-
-
-        -------------------------------------------------------------------------------------------
-        Arguments
-        -------------------------------------------------------------------------------------------
-
-        Displacement_Frames : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
-            Displacement_Frames[i, ...] represents the displacement portion of the i'th FOM frame.
-            Here, N_Frames is the number of frames we want to encode and reshape_shape specifies 
-            the shape of each frame. 
-
-        Velocity_Frames : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
-            Velocity_Frames[i, ...] represents the velocity portion of the i'th FOM frame. Here, 
-            N_Frames is the number of frames we want to encode for each parameter combination and 
-            reshape_shape specifies the shape of each frame. 
-
-
-        -------------------------------------------------------------------------------------------
-        Returns
-        -------------------------------------------------------------------------------------------
-
-        Reconstructed_Displacement, Reconstructed_Velocity
-
-        Reconstructed_Displacement : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
-            Reconstructed_Displacement[i, ...] represents the reconstruction of the displacement 
-            portion of the i'th FOM frame. 
-
-        Reconstructed_Velocity : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
-            Reconstructed_Velocity[i, ...] represents the reconstruction of the velocity portion 
-            of i'th FOM frame.
-        """
-
-        # Encode the displacement, velocity frames
-        Latent_Displacement, Latent_Velocity = self.Encode(     Displacement_Frames   = Displacement_Frames, 
-                                                                Velocity_Frames       = Velocity_Frames);
-
-        # Now reconstruct displacement, velocity.
-        Reconstructed_Displacement, Reconstructed_Velocity = self.Decode(
-                                                                Latent_Displacement = Latent_Displacement, 
-                                                                Latent_Velocity     = Latent_Velocity);
-
-        # All done!
-        return Reconstructed_Displacement, Reconstructed_Velocity;
-
-
 
 
 
@@ -291,7 +291,8 @@ class Autoencoder_Pair(EncoderDecoder):
                     'widths'            : self.widths,
                     'activations'       : self.activations,
                     'Displacement dict' : self.cpu().Displacement_Autoencoder.export(),
-                    'Velocity dict'     : self.cpu().Velocity_Autoencoder.export()};
+                    'Velocity dict'     : self.cpu().Velocity_Autoencoder.export(),
+                    'config'            : self.config};
         return dict_;
     
 
@@ -327,13 +328,11 @@ def load_Autoencoder_Pair(dict_ : dict) -> Autoencoder_Pair:
     # First, extract the information we need to initialize a Autoencoder_Pair object with the same 
     # architecture as the one that created dict_.
     reshape_shape   : list[int] = dict_['reshape_shape'];
-    widths          : list[int] = dict_['widths'];
-    activations     : list[str] = dict_['activations'];
+    config          : dict      = dict_['config'];
 
     # Now initialize the Autoencoder_Pair.
-    AEP                     = Autoencoder_Pair( widths          = widths, 
-                                                activations     = activations,
-                                                reshape_shape   = reshape_shape);
+    AEP                     = Autoencoder_Pair( reshape_shape   = reshape_shape,
+                                                config          = config);
     
     # Now replace its auto-encoders.
     AEP.Displacement_Autoencoder    = load_Autoencoder(dict_['Displacement dict']);

--- a/src/EncoderDecoder/Autoencoder_Pair.py
+++ b/src/EncoderDecoder/Autoencoder_Pair.py
@@ -92,10 +92,10 @@ class Autoencoder_Pair(EncoderDecoder):
         assert "activations"        in pair_config;
         assert "n_Decoders"         in pair_config;
         
-        assert isinstance(Frame_Shape, list),                 "type(Frame_Shape) == %s, expected list" % (str(type(reshape_shape)));
+        assert isinstance(Frame_Shape, list),                 "type(Frame_Shape) == %s, expected list" % (str(type(Frame_Shape)));
         for i in range(len(Frame_Shape)):
-            assert isinstance(Frame_Shape[i], int),           "type(Frame_Shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
-            assert Frame_Shape[i] > 0,                        "Frame_Shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
+            assert isinstance(Frame_Shape[i], int),           "type(Frame_Shape[%d]) = %s, expected int" % (i, str(type(Frame_Shape[i])));
+            assert Frame_Shape[i] > 0,                        "Frame_Shape[%d] = %d, needs to be positive" % (i, Frame_Shape[i]);
         
 
 
@@ -125,7 +125,7 @@ class Autoencoder_Pair(EncoderDecoder):
         for i in range(len(widths)):
             assert isinstance(widths[i], int),                  "type(widths[%d]) = %s, must be int" % (i, str(type(widths[i])));
             assert widths[i] > 0,                               "widths[%d] = %d, must be positive" % (i, widths[i]);
-        assert numpy.prod(Frame_Shape) == widths[0],            "numpy.prod(self.reshape_shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(reshape_shape), widths[0]);
+        assert numpy.prod(Frame_Shape) == widths[0],            "numpy.prod(self.Frame_Shape) = %d, widths[0] = %d; must be equal" % (numpy.prod(Frame_Shape), widths[0]);
 
         # Extract the number of decoders.
         n_Decoders = config[pair_key]['n_Decoders'];
@@ -136,7 +136,7 @@ class Autoencoder_Pair(EncoderDecoder):
 
         # In general, the FOM solution may be vector valued and have multiple spatial dimensions. 
         # We need to know the shape of each FOM frame. 
-        self.reshape_shape  : list[int]     = Frame_Shape; 
+        self.Frame_Shape    : list[int]     = Frame_Shape; 
         
         # Fetch information about the domain/co-domain.
         self.widths         : list[int]     = widths;
@@ -146,20 +146,17 @@ class Autoencoder_Pair(EncoderDecoder):
 
         # Make a config for the AE.
         ae_config = deepcopy(config);
-        ae_config['ae'] = deepcopy(config[pair_key]);
+        ae_config['type']   = 'ae';
+        ae_config['ae']     = deepcopy(config[pair_key]);
         del ae_config[pair_key];
 
         # Next, build the velocity and displacement auto-encoders.
         LOGGER.info("Initializing the Displacement Autoencoder...");
-        self.Displacement_Autoencoder   = Autoencoder(  widths          = widths, 
-                                                        activations     = activations, 
-                                                        reshape_shape   = self.reshape_shape,
+        self.Displacement_Autoencoder   = Autoencoder(  Frame_Shape     = self.Frame_Shape,
                                                         config          = ae_config);
 
         LOGGER.info("Initializing the Velocity Autoencoder...");
-        self.Velocity_Autoencoder       = Autoencoder(  widths          = widths, 
-                                                        activations     = activations,
-                                                        reshape_shape   = self.reshape_shape,
+        self.Velocity_Autoencoder       = Autoencoder(  Frame_Shape     = self.Frame_Shape,
                                                         config          = ae_config);
 
 
@@ -175,15 +172,15 @@ class Autoencoder_Pair(EncoderDecoder):
         Arguments
         -------------------------------------------------------------------------------------------
 
-        Displacement_Frames : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
+        Displacement_Frames : torch.Tensor, shape = (N_Frames,) + self.Frame_Shape
             Displacement_Frames[i, ...] represents the displacement portion of the i'th FOM frame.
-            Here, N_Frames is the number of frames we want to encode and reshape_shape specifies 
+            Here, N_Frames is the number of frames we want to encode and Frame_Shape specifies 
             the shape of each frame. 
 
-        Velocity_Frames : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
+        Velocity_Frames : torch.Tensor, shape = (N_Frames,) + self.Frame_Shape
             Velocity_Frames[i, ...] represents the velocity portion of the i'th FOM frame. Here, 
             N_Frames is the number of frames we want to encode for each parameter combination and 
-            reshape_shape specifies the shape of each frame. 
+            Frame_Shape specifies the shape of each frame. 
         
 
         -------------------------------------------------------------------------------------------
@@ -204,9 +201,9 @@ class Autoencoder_Pair(EncoderDecoder):
         # Check that we have the same number of displacement, velocity frames.
         assert isinstance(Displacement_Frames, torch.Tensor),   "type(Displacement_Frames) = %s; must be torch.Tensor" % str(type(Displacement_Frames));
         assert isinstance(Velocity_Frames, torch.Tensor),       "type(Velocity_Frames) = %s; must be torch.Tensor" % str(type(Velocity_Frames));
-        assert len(Displacement_Frames.shape)       ==  len(self.reshape_shape) + 1,    "Displacement_Frames.shape = %s, length must be len(self.reshape_shape) (self.reshape_shape = %s) + 1" % (str(Displacement_Frames.shape), str(self.reshape_shape));
+        assert len(Displacement_Frames.shape)       ==  len(self.Frame_Shape) + 1,    "Displacement_Frames.shape = %s, length must be len(self.Frame_Shape) (self.Frame_Shape = %s) + 1" % (str(Displacement_Frames.shape), str(self.Frame_Shape));
         assert Displacement_Frames.shape            ==  Velocity_Frames.shape,          "Displacement_Frames.shape = %s, Velocity_Frames.shape = %s" % (str(Displacement_Frames.shape), str(Velocity_Frames.shape));
-        assert list(Displacement_Frames.shape[1:])  ==  self.reshape_shape,             "list(Displacement_Frames.shape[1:]) = %s, self.reshape_shape = %s; must be equal" % (str(list(Displacement_Frames.shape[1:])), str(self.reshape_shape));
+        assert list(Displacement_Frames.shape[1:])  ==  self.Frame_Shape,             "list(Displacement_Frames.shape[1:]) = %s, self.Frame_Shape = %s; must be equal" % (str(list(Displacement_Frames.shape[1:])), str(self.Frame_Shape));
     
         # Encode the displacement frames.
         Latent_Displacement : torch.Tensor = self.Displacement_Autoencoder.Encode( Displacement_Frames)[0];
@@ -247,11 +244,11 @@ class Autoencoder_Pair(EncoderDecoder):
 
         Reconstructed_Displacement, Reconstructed_Velocity
          
-        Reconstructed_Displacement : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
+        Reconstructed_Displacement : torch.Tensor, shape = (N_Frames,) + self.Frame_Shape
             Reconstructed_Displacement[i, ...] represents the reconstruction of the displacement 
             portion of the i'th FOM frame. 
 
-        Reconstructed_Velocity : torch.Tensor, shape = (N_Frames,) + self.reshape_shape
+        Reconstructed_Velocity : torch.Tensor, shape = (N_Frames,) + self.Frame_Shape
             Reconstructed_Velocity[i, ...] represents the reconstruction of the velocity portion 
             of i'th FOM frame.
         """
@@ -261,7 +258,7 @@ class Autoencoder_Pair(EncoderDecoder):
         assert isinstance(Latent_Velocity, torch.Tensor),       "type(Latent_Velocity) = %s; must be torch.Tensor" % str(type(Latent_Velocity));
         assert len(Latent_Displacement.shape)   == 2,           "Latent_Displacement.shape = %s; must have length 2" % str(Latent_Displacement.shape);
         assert Latent_Velocity.shape            == Latent_Displacement.shape,   "Latent_Velocity.shape = %s, Latent_Displacement.shape = %s; must be equal" % (str(Latent_Displacement.shape), str(Latent_Velocity.shape));
-        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),          "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders),              "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
 
         # Encode the displacement frames.
         Reconstructed_Displacement  : torch.Tensor  = self.Displacement_Autoencoder.Eval_Decoder( i_Decoder, Latent_Displacement)[0];
@@ -281,18 +278,19 @@ class Autoencoder_Pair(EncoderDecoder):
 
         This function extracts everything we need to recreate self from scratch. Specifically, we 
         extract the encoder/decoder state dictionaries, self's architecture, activation function 
-        and reshape_shape. We store and return this information in a dictionary.
+        and Frame_Shape. We store and return this information in a dictionary.
          
         You can pass the returned dictionary to the load_Autoencoder_Pair method to generate an 
         Autoencoder object that is identical to self.
         """
 
-        dict_ = {   'reshape_shape'     : self.reshape_shape,
-                    'widths'            : self.widths,
-                    'activations'       : self.activations,
-                    'Displacement dict' : self.cpu().Displacement_Autoencoder.export(),
-                    'Velocity dict'     : self.cpu().Velocity_Autoencoder.export(),
-                    'config'            : self.config};
+        dict_ = {   'EncoderDecoder dict'   : super().export(),
+                    'Frame_Shape'           : self.Frame_Shape,
+                    'widths'                : self.widths,
+                    'activations'           : self.activations,
+                    'Displacement dict'     : self.cpu().Displacement_Autoencoder.export(),
+                    'Velocity dict'         : self.cpu().Velocity_Autoencoder.export(),
+                    'config'                : self.config};
         return dict_;
     
 
@@ -327,13 +325,16 @@ def load_Autoencoder_Pair(dict_ : dict) -> Autoencoder_Pair:
 
     # First, extract the information we need to initialize a Autoencoder_Pair object with the same 
     # architecture as the one that created dict_.
-    reshape_shape   : list[int] = dict_['reshape_shape'];
+    Frame_Shape   : list[int] = dict_['Frame_Shape'];
     config          : dict      = dict_['config'];
 
     # Now initialize the Autoencoder_Pair.
-    AEP                     = Autoencoder_Pair( reshape_shape   = reshape_shape,
+    AEP                     = Autoencoder_Pair( Frame_Shape     = Frame_Shape,
                                                 config          = config);
     
+    # Set the Decoder_Weights, Active.
+    AEP.load(dict_ = dict_['EncoderDecoder dict']);
+
     # Now replace its auto-encoders.
     AEP.Displacement_Autoencoder    = load_Autoencoder(dict_['Displacement dict']);
     AEP.Velocity_Autoencoder        = load_Autoencoder(dict_['Velocity dict']);

--- a/src/EncoderDecoder/CNN_3D_Autoencoder.py
+++ b/src/EncoderDecoder/CNN_3D_Autoencoder.py
@@ -285,7 +285,7 @@ class CNN_3D_Autoencoder(EncoderDecoder):
         self.conv_paddings      : list[tuple[int, int, int]] = _expand_3tuple_param(conv_paddings,     self.n_conv_layers, "conv_paddings");
 
         LOGGER.info("Initializing a CNN_3D_Autoencoder with latent space dimension %d" % self.n_z);
-        LOGGER.info("  Reshape shape:       %s" % str(self.reshape_shape));
+        LOGGER.info("  Frame shape:         %s" % str(self.Frame_Shape));
         LOGGER.info("  Conv channels:       %s" % str(self.conv_channels));
         LOGGER.info("  Conv kernels:        %s" % str(self.conv_kernel_sizes));
         LOGGER.info("  Conv strides:        %s" % str(self.conv_strides));
@@ -339,7 +339,7 @@ class CNN_3D_Autoencoder(EncoderDecoder):
                                 reshape_shape       = []));
 
         # Build decoder conv stack (transpose convs), mirroring encoder.
-        self.decoder_convs      = torch.nn.ModuleList([]);
+        self.decoder_convs      = torch.nn.ModuleList([]);          # shape (n_conv_layers, n_Decoders)
         self._output_paddings   : list[tuple[int, int, int]] = [];
 
         # Encoder shapes: s0 -> s1 -> ... -> sL, where L = n_conv_layers.
@@ -468,7 +468,7 @@ class CNN_3D_Autoencoder(EncoderDecoder):
         assert isinstance(Z, torch.Tensor), "type(Z) = %s, must be torch.Tensor" % str(type(Z));
         assert len(Z.shape) == 2,           "Z.shape = %s, must have length 2" % str(Z.shape);
         assert Z.shape[1] == self.n_z,      "Z.shape[1] = %d, self.n_z = %d; must match" % (Z.shape[1], self.n_z);
-        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders),  "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
 
         # FC decoder.
         U : torch.Tensor = self.fc_decoders[i_Decoder](Z);
@@ -476,7 +476,7 @@ class CNN_3D_Autoencoder(EncoderDecoder):
 
         # Conv transpose decoder.
         for i in range(self.n_conv_layers):
-            U = self.decoder_convs[i_Decoder][i](self._decoder_conv_act_fns[i](U));
+            U = self.decoder_convs[i][i_Decoder](self._decoder_conv_act_fns[i](U));
 
         assert list(U.shape[-3:]) == self.reshape_shape, "Decoded output shape mismatch: got %s, expected (n_Frames, %s)" % (str(U.shape), str(self.reshape_shape));
         assert U.shape[1] == self.conv_channels[0], "Decoded channel mismatch: got %d, expected %d" % (U.shape[1], self.conv_channels[0]);
@@ -488,11 +488,15 @@ class CNN_3D_Autoencoder(EncoderDecoder):
         """
         This function extracts everything we need to recreate self from scratch.
         """
-
-        dict_ = {   'encoder conv state'  : self.encoder_convs.cpu().state_dict(),
+        decoders_list = [];
+        for i in range(self.n_Decoders):
+            decoders_list.append(self.fc_decoders[i].cpu().state_dict());
+        
+        dict_ = {   'EncoderDecoder dict' : super().export(),
+                    'encoder conv state'  : self.encoder_convs.cpu().state_dict(),
                     'decoder conv state'  : self.decoder_convs.cpu().state_dict(),
                     'encoder fc state'    : self.encoder_fc.cpu().state_dict(),
-                    'decoder fc state'    : self.decoder_fc.cpu().state_dict(),
+                    'fc decoders state'   : decoders_list,
                     'reshape_shape'       : self.reshape_shape,
                     'latent_dimension'    : self.n_z,
                     'hidden_widths_fc'    : self.hidden_widths_fc,
@@ -516,25 +520,21 @@ def load_CNN_3D_Autoencoder(dict_ : dict) -> CNN_3D_Autoencoder:
 
     LOGGER.info("De-serializing a CNN_3D_Autoencoder..." );
 
-    reshape_shape       : list[int]     = dict_['reshape_shape'];
-    latent_dimension    : int           = dict_['latent_dimension'];
-    hidden_widths_fc    : list[int]     = dict_['hidden_widths_fc'];
-    activations_fc      : list[str]     = dict_['activations_fc'];
-
-    conv_channels       : list[int]     = dict_['conv_channels'];
-    conv_kernel_sizes                   = dict_['conv_kernel_sizes'];
-    conv_strides                        = dict_['conv_strides'];
-    conv_paddings                       = dict_['conv_paddings'];
-    conv_activations    : list[str]     = dict_['conv_activations'];
-
-    model = CNN_3D_Autoencoder( Frame_Shape     = dict_['Frame_Shape'],
+    # Build the model.
+    CNN = CNN_3D_Autoencoder( Frame_Shape     = dict_['Frame_Shape'],
                                 config          = dict_['config']);
 
-    model.encoder_convs.load_state_dict(dict_['encoder conv state']);
-    model.encoder_fc[i].load_state_dict(dict_['encoder fc state']);
+    
+    # Set the decoder weights/active.
+    CNN.load(dict_ = dict_['EncoderDecoder dict']);
 
-    for i in range(model.n_Decoders):
-        model.decoder_convs[i].load_state_dict(dict_['decoder conv state']);
-        model.decoder_fc[i].load_state_dict(dict_['decoder fc state']);
+    # Load the state dictionaries
+    CNN.encoder_convs.load_state_dict(dict_['encoder conv state']);
+    CNN.encoder_fc.load_state_dict(dict_['encoder fc state']);
+    CNN.decoder_convs.load_state_dict(dict_['decoder conv state'])
 
-    return model;
+    for i in range(CNN.n_Decoders):
+        CNN.fc_decoders[i].load_state_dict(dict_['fc decoders state'][i]);
+
+    # All done!
+    return CNN;

--- a/src/EncoderDecoder/CNN_3D_Autoencoder.py
+++ b/src/EncoderDecoder/CNN_3D_Autoencoder.py
@@ -98,15 +98,8 @@ def _conv3d_out_shape(   in_shape    : tuple[int, int, int],
 
 class CNN_3D_Autoencoder(EncoderDecoder):
     def __init__(   self,
-                    reshape_shape       : list[int],
-                    hidden_widths_fc    : list[int],
-                    activations_fc      : list[str],
-                    latent_dimension    : int,
-                    conv_channels       : list[int],
-                    conv_activations    : list[str],
-                    conv_kernel_sizes   : int | Sequence[int] | Sequence[Sequence[int]],
-                    conv_strides        : int | Sequence[int] | Sequence[Sequence[int]]  = 2,
-                    conv_paddings       : int | Sequence[int] | Sequence[Sequence[int]]  = 1) -> None:
+                    Frame_Shape         : list[int],
+                    config              : dict) -> None:
         r"""
         Initializes a convolutional autoencoder for 3D spatial data. This model applies a stack
         of 3D convolutions to a 3D image, flattens the resulting feature map, and then applies a
@@ -118,45 +111,55 @@ class CNN_3D_Autoencoder(EncoderDecoder):
         Arguments
         -------------------------------------------------------------------------------------------
 
-        reshape_shape : list[int], len = 3
-            Specifies the spatial shape (I, J, K) of each input frame. Inputs to Encode/forward
-            can either  have shape (n_Frames, C, I, J, K) or (n_Frames, C, I*J*K), where 
-            C = conv_channels[0]. In the latter case, we reshape the input to have shape 
-            (n_Frames, C, I, J, K)
+        Frame_Shape : list[int], len = 3
+            The shape of elements of the FOM space. Specifies the spatial shape (C, I, J, K) of 
+            each input frame. Inputs to Encode/forward can either  have shape 
+            (n_Frames, C, I, J, K) or (n_Frames, C, I*J*K), where C = conv_channels[0]. In the 
+            latter case, we reshape the input to have shape (n_Frames, C, I, J, K).
 
-        hidden_widths_fc : list[int]
-            A list of integers specifying the widths of the hidden fully-connected layers. The
-            encoder's final fully-connected layer maps to the latent space of dimension
-            latent_dimension. The decoder uses the reversed widths.
+            
+        config: dict
+            The "EncoderDecoder" sub dictionary of the configuration file. It must contain a "type"
+            key whose value is either "cnn_3d", "cnn_3d_ae", or "cnn_3d_autoencoder". There must 
+            also be an item whose key matches the value of the "type" key and whose value is a 
+            dictionary specifying the settings to define the CNN_3D_Autoencoder object. Namely, 
+            it must contain the following keys:
 
-        activations_fc : list[str], len = len(hidden_widths_fc)
-            Activation(s) for the hidden fully-connected layers. The i'th element holds the name 
-            of the activation function we apply after the i'th fully-connected layer of the encoder.
-            Note that we do not apply an activation function to the output of the final fully c
-            connected layer. The decoder uses the reversed list.
 
-        latent_dimension : int
-            The dimension of the latent space.
+            hidden_widths_fc : list[int]
+                A list of integers specifying the widths of the hidden fully-connected layers. The
+                encoder's final fully-connected layer maps to the latent space of dimension
+                latent_dimension. The decoder uses the reversed widths.
 
-        conv_channels : list[int]
-            A list whose i'th element specifies the number of channels after the i-1'th convolution.
-            Equivalently, conv_channels[i] is the number of input channels to the i'th convolutional
-            layer. Thus, if this list has M entries then the conv encoder has M-1 layers mapping
-            conv_channels[i] -> conv_channels[i+1]. The decoder mirrors this structure.
+            activations_fc : list[str], len = len(hidden_widths_fc)
+                Activation(s) for the hidden fully-connected layers. The i'th element holds the name 
+                of the activation function we apply after the i'th fully-connected layer of the encoder.
+                Note that we do not apply an activation function to the output of the final fully c
+                connected layer. The decoder uses the reversed list.
 
-        conv_activations : list[str], len = len(conv_channels) - 1
-            i'th element specifies the activation function we apply after the i'th convolutional 
-            layer. The decoder uses the reversed list.
+            latent_dimension : int
+                The dimension of the latent space.
 
-        conv_kernel_sizes, conv_strides, conv_paddings:
-            Convolution hyperparameters. Each can be:
-                - an int (used for all layers in all three dimensions),
-                - a length-3 sequence (used for all layers),
-                - a list of length len(conv_channels) - 1 of length-3 sequences (one per layer).
+            conv_channels : list[int]
+                A list whose i'th element specifies the number of channels after the i-1'th convolution.
+                Equivalently, conv_channels[i] is the number of input channels to the i'th convolutional
+                layer. Thus, if this list has M entries then the conv encoder has M-1 layers mapping
+                conv_channels[i] -> conv_channels[i+1]. The decoder mirrors this structure.
 
-            Note: By default, conv_strides=2 (i.e., we downsample at every conv layer). This is
-            the "reduction operation" used by default.
+            conv_activations : list[str], len = len(conv_channels) - 1
+                i'th element specifies the activation function we apply after the i'th convolutional 
+                layer. The decoder uses the reversed list.
 
+            conv_kernel_sizes, conv_strides, conv_paddings:
+                Convolution hyperparameters. Each can be:
+                    - an int (used for all layers in all three dimensions),
+                    - a length-3 sequence (used for all layers),
+                    - a list of length len(conv_channels) - 1 of length-3 sequences (one per layer).
+
+                Note: By default, conv_strides=2 (i.e., we downsample at every conv layer). This is
+                the "reduction operation" used by default.
+
+            
 
         -------------------------------------------------------------------------------------------
         Returns
@@ -165,19 +168,18 @@ class CNN_3D_Autoencoder(EncoderDecoder):
         Nothing!
         """
 
-        # Checks: reshape_shape.
-        assert isinstance(reshape_shape, list),                 "type(reshape_shape) == %s, expected list" % (str(type(reshape_shape)));
-        assert len(reshape_shape) == 3,                         "len(reshape_shape) = %d, expected 3" % len(reshape_shape);
-        for i in range(len(reshape_shape)):
-            assert isinstance(reshape_shape[i], int),               "type(reshape_shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
-            assert reshape_shape[i] > 0,                            "reshape_shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
+        # Input checks.
+        assert 'type' in config;
+        assert (config['type'] == "cnn_3d") or (config['type'] == "cnn_3d_ae") or (config['type'] == "cnn_3d_autoencoder");
+        cnn_key  : str = config['type'];
+        assert cnn_key in config;
+        cnn_config              : dict              = config[cnn_key];
 
-        # Checks: conv params.
-        assert isinstance(conv_channels, list),                 "type(conv_channels) = %s, expected list" % str(type(conv_channels));
-        assert len(conv_channels) >= 2,                         "len(conv_channels) = %d; must be at least 2 (input + output channels)" % len(conv_channels);
-        for i in range(len(conv_channels)):
-            assert isinstance(conv_channels[i], int),               "type(conv_channels[%d]) = %s, must be int" % (i, str(type(conv_channels[i])));
-            assert conv_channels[i] > 0,                            "conv_channels[%d] = %d, must be positive" % (i, conv_channels[i]);
+
+
+        # FC configuration (analogous to the AE's hidden_widths/activations).
+        hidden_widths_fc        : list[int]         = cnn_config.get('hidden_widths_fc', cnn_config.get('hidden_widths'));
+        latent_dimension        : int               = cnn_config['latent_dimension'];
 
         # Checks: FC params.
         assert isinstance(hidden_widths_fc, list),              "type(hidden_widths_fc) = %s, expected list" % str(type(hidden_widths_fc));
@@ -187,15 +189,55 @@ class CNN_3D_Autoencoder(EncoderDecoder):
         assert isinstance(latent_dimension, int),               "type(latent_dimension) = %s, must be int" % str(type(latent_dimension));
         assert latent_dimension > 0,                            "latent_dimension = %d, must be positive" % latent_dimension;
 
-        # activations_fc
-        assert isinstance(activations_fc, list),                "type(activations_fc) = %s, must be list" % str(type(activations_fc));
+
+
+        # FC activations can either be a string or a list of strings.
+        n_hidden_layers         : int               = len(hidden_widths_fc);
+        act_cfg = cnn_config.get('activations_fc', cnn_config.get('activations'));
+        if(isinstance(act_cfg, str)):
+            activations_fc      : list[str]        = [act_cfg] * n_hidden_layers;
+        elif(isinstance(act_cfg, list)):
+            activations_fc      : list[str]        = act_cfg;
+            assert(len(activations_fc) == n_hidden_layers);
+        else:
+            raise ValueError("activations_fc must be a string or a list of strings.");
+
+        # Checks: activations_fc
         assert len(activations_fc) == len(hidden_widths_fc), \
             "len(activations_fc) = %d, len(hidden_widths_fc) = %d; must match" % (len(activations_fc), len(hidden_widths_fc));
         for i in range(len(activations_fc)):
             assert isinstance(activations_fc[i], str),             "type(activations_fc[%d]) = %s, must be str" % (i, str(type(activations_fc[i])));
             assert activations_fc[i].lower() in act_dict.keys(),   "activations_fc[%d] = %s; not in act_dict keys" % (i, activations_fc[i].lower());
 
-        # conv_activations
+
+
+        # Conv configuration.
+        conv_channels       : list[int]     = cnn_config['conv_channels'];
+        conv_kernel_sizes                   = cnn_config.get('conv_kernel_sizes', 3);
+        conv_strides                        = cnn_config.get('conv_strides', 2);
+        conv_paddings                       = cnn_config.get('conv_paddings', 1);
+
+        # Checks: conv params.
+        assert isinstance(conv_channels, list),                 "type(conv_channels) = %s, expected list" % str(type(conv_channels));
+        assert len(conv_channels) >= 2,                         "len(conv_channels) = %d; must be at least 2 (input + output channels)" % len(conv_channels);
+        for i in range(len(conv_channels)):
+            assert isinstance(conv_channels[i], int),               "type(conv_channels[%d]) = %s, must be int" % (i, str(type(conv_channels[i])));
+            assert conv_channels[i] > 0,                            "conv_channels[%d] = %d, must be positive" % (i, conv_channels[i]);
+
+
+
+        # Per-layer conv activations. This can be a string (use same activation for all conv layers)
+        # or a list of strings of length len(conv_channels) - 1.
+        conv_act_cfg = cnn_config.get('conv_activations', 'relu');
+        if(isinstance(conv_act_cfg, str)):
+            conv_activations : list[str] = [conv_act_cfg] * (len(conv_channels) - 1);
+        elif(isinstance(conv_act_cfg, list)):
+            conv_activations = conv_act_cfg;
+            assert(len(conv_activations) == len(conv_channels) - 1);
+        else:
+            raise ValueError("conv_activations must be a string or a list of strings.");
+
+        # Checks: conv_activations
         assert isinstance(conv_activations, list),                "type(conv_activations) = %s, must be list" % str(type(conv_activations));
         n_conv_layers : int = len(conv_channels) - 1;
         assert len(conv_activations) == n_conv_layers, \
@@ -205,11 +247,30 @@ class CNN_3D_Autoencoder(EncoderDecoder):
             assert conv_activations[i].lower() in act_dict.keys(),  "conv_activations[%d] = %s; not in act_dict keys" % (i, conv_activations[i].lower());
 
 
+
+        # Fetch Frame_Shape from physics (must be 3D for Conv3d).
+        assert(len(Frame_Shape) == 4), "physics.Frame_Shape = %s; Conv_Autoencoder requires a 3D spatial shape" % str(Frame_Shape);
+        C               : int       = int(Frame_Shape[0]);
+        reshape_shape   : list[int] = [int(x) for x in Frame_Shape[1:]];
+        
+        # Checks: Frame_Shape.
+        assert conv_channels[0] == C, "conv_chanels[0] = %d, but the data has %d channels. These must match" % (conv_channels[0], C);
+        assert len(reshape_shape) == 3,                             "len(reshape_shape) = %d, expected 3" % len(reshape_shape);
+        for i in range(len(reshape_shape)):
+            assert isinstance(reshape_shape[i], int),               "type(reshape_shape[%d]) = %s, expected int" % (i, str(type(reshape_shape[i])));
+            assert reshape_shape[i] > 0,                            "reshape_shape[%d] = %d, needs to be positive" % (i, reshape_shape[i]);
+        
+
+
+        # Extract n_Decoders
+        n_Decoders = config[cnn_key]['n_Decoders'];
+
         # Run the superclass initializer.
-        super().__init__(n_IC   = 1, n_z = latent_dimension);
+        super().__init__(n_IC   = 1, n_z = latent_dimension, n_Decoders = n_Decoders, config = config);
 
         # Store information (for return purposes).
         self.reshape_shape      : list[int]     = reshape_shape;
+        self.Frame_Shape        : list[int]     = Frame_Shape;
 
         self.conv_channels      : list[int]     = conv_channels;
         self.conv_activations   : list[str]     = conv_activations;
@@ -269,11 +330,13 @@ class CNN_3D_Autoencoder(EncoderDecoder):
                             reshape_index       = 1,
                             reshape_shape       = []);
 
-        self.decoder_fc = MultiLayerPerceptron(
-                            widths              = widths_fc_decoder,
-                            activations         = self.activations_fc[::-1],
-                            reshape_index       = 1,
-                            reshape_shape       = []);
+        self.fc_decoders = torch.nn.ModuleList([]);
+        for i in range(self.n_Decoders):
+            self.fc_decoders.append(MultiLayerPerceptron(
+                                widths              = widths_fc_decoder,
+                                activations         = self.activations_fc[::-1],
+                                reshape_index       = 1,
+                                reshape_shape       = []));
 
         # Build decoder conv stack (transpose convs), mirroring encoder.
         self.decoder_convs      = torch.nn.ModuleList([]);
@@ -302,13 +365,16 @@ class CNN_3D_Autoencoder(EncoderDecoder):
             output_padding : tuple[int, int, int] = (op[0], op[1], op[2]);
             self._output_paddings.append(output_padding);
 
-            self.decoder_convs.append(torch.nn.ConvTranspose3d(
-                                        in_channels     = in_c,
-                                        out_channels    = out_c,
-                                        kernel_size     = k,
-                                        stride          = st,
-                                        padding         = p,
-                                        output_padding  = output_padding));
+            ith_decoder_convs = torch.nn.ModuleList([]);
+            for j in range(self.n_Decoders):
+                ith_decoder_convs.append(torch.nn.ConvTranspose3d(
+                                            in_channels     = in_c,
+                                            out_channels    = out_c,
+                                            kernel_size     = k,
+                                            stride          = st,
+                                            padding         = p,
+                                            output_padding  = output_padding));
+            self.decoder_convs.append(ith_decoder_convs);
 
         # Cache activation functions.
         self._encoder_conv_act_fns : list[Callable] = [];
@@ -373,7 +439,7 @@ class CNN_3D_Autoencoder(EncoderDecoder):
 
 
 
-    def Decode(self, Z : torch.Tensor) -> tuple[torch.Tensor]:
+    def Eval_Decoder(self, i_Decoder : int, Z : torch.Tensor) -> tuple[torch.Tensor]:
         """
         This function decodes a set of latent frames.
 
@@ -381,6 +447,9 @@ class CNN_3D_Autoencoder(EncoderDecoder):
         -------------------------------------------------------------------------------------------
         Arguments
         -------------------------------------------------------------------------------------------
+
+        i_Decoder : int
+            the index of the decoder we want to use to decode Z.
 
         Z : torch.Tensor, shape = (n_Frames, self.n_z)
            i,j element holds the j'th component of the encoding of the i'th frame.
@@ -397,50 +466,21 @@ class CNN_3D_Autoencoder(EncoderDecoder):
 
         # Checks.
         assert isinstance(Z, torch.Tensor), "type(Z) = %s, must be torch.Tensor" % str(type(Z));
-        assert len(Z.shape) == 2,          "Z.shape = %s, must have length 2" % str(Z.shape);
-        assert Z.shape[1] == self.n_z,     "Z.shape[1] = %d, self.n_z = %d; must match" % (Z.shape[1], self.n_z);
+        assert len(Z.shape) == 2,           "Z.shape = %s, must have length 2" % str(Z.shape);
+        assert Z.shape[1] == self.n_z,      "Z.shape[1] = %d, self.n_z = %d; must match" % (Z.shape[1], self.n_z);
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}, got %d" % (self.n_Decoders - 1, i_Decoder);
 
         # FC decoder.
-        U : torch.Tensor = self.decoder_fc(Z);
+        U : torch.Tensor = self.fc_decoders[i_Decoder](Z);
         U = U.view((U.shape[0], self._conv_latent_channels) + self._conv_latent_shape);
 
         # Conv transpose decoder.
         for i in range(self.n_conv_layers):
-            U = self.decoder_convs[i](self._decoder_conv_act_fns[i](U));
+            U = self.decoder_convs[i_Decoder][i](self._decoder_conv_act_fns[i](U));
 
         assert list(U.shape[-3:]) == self.reshape_shape, "Decoded output shape mismatch: got %s, expected (n_Frames, %s)" % (str(U.shape), str(self.reshape_shape));
         assert U.shape[1] == self.conv_channels[0], "Decoded channel mismatch: got %d, expected %d" % (U.shape[1], self.conv_channels[0]);
         return (U,);
-
-
-
-    def forward(self, X : torch.Tensor) -> tuple[torch.Tensor]:
-        """
-        This function passes X through the encoder, producing a latent state, Z. It then passes 
-        Z through the decoder; hopefully producing a vector that approximates X.
-        
-
-        -------------------------------------------------------------------------------------------
-        Arguments
-        -------------------------------------------------------------------------------------------
-
-        U : torch.Tensor, shape = (n_Frames,) + self.reshape_shape
-            A tensor holding a batch of inputs. We pass this tensor through the encoder + decoder 
-            and then return the result.
-
-
-        -------------------------------------------------------------------------------------------
-        Returns
-        -------------------------------------------------------------------------------------------
-
-        Y : tuple[torch.Tensor], len = 1
-            A single element tuple whose lone element is a torch.Tensor of shape = X.shape holding 
-            the image of X under the encoder and decoder. 
-        """
-
-        Z : torch.Tensor        = self.Encode(X)[0];
-        Y : tuple[torch.Tensor] = self.Decode(Z);
-        return Y;
 
 
 
@@ -461,7 +501,9 @@ class CNN_3D_Autoencoder(EncoderDecoder):
                     'conv_kernel_sizes'   : self.conv_kernel_sizes,
                     'conv_strides'        : self.conv_strides,
                     'conv_paddings'       : self.conv_paddings,
-                    'conv_activations'    : self.conv_activations};
+                    'conv_activations'    : self.conv_activations,
+                    'Frame_Shape'         : self.Frame_Shape,
+                    'config'              : self.config};
         return dict_;
 
 
@@ -485,19 +527,14 @@ def load_CNN_3D_Autoencoder(dict_ : dict) -> CNN_3D_Autoencoder:
     conv_paddings                       = dict_['conv_paddings'];
     conv_activations    : list[str]     = dict_['conv_activations'];
 
-    model = CNN_3D_Autoencoder( reshape_shape        = reshape_shape,
-                                hidden_widths_fc     = hidden_widths_fc,
-                                activations_fc       = activations_fc,
-                                latent_dimension     = latent_dimension,
-                                conv_channels        = conv_channels,
-                                conv_kernel_sizes    = conv_kernel_sizes,
-                                conv_strides         = conv_strides,
-                                conv_paddings        = conv_paddings,
-                                conv_activations     = conv_activations);
+    model = CNN_3D_Autoencoder( Frame_Shape     = dict_['Frame_Shape'],
+                                config          = dict_['config']);
 
     model.encoder_convs.load_state_dict(dict_['encoder conv state']);
-    model.decoder_convs.load_state_dict(dict_['decoder conv state']);
-    model.encoder_fc.load_state_dict(dict_['encoder fc state']);
-    model.decoder_fc.load_state_dict(dict_['decoder fc state']);
+    model.encoder_fc[i].load_state_dict(dict_['encoder fc state']);
+
+    for i in range(model.n_Decoders):
+        model.decoder_convs[i].load_state_dict(dict_['decoder conv state']);
+        model.decoder_fc[i].load_state_dict(dict_['decoder fc state']);
 
     return model;

--- a/src/EncoderDecoder/EncoderDecoder.py
+++ b/src/EncoderDecoder/EncoderDecoder.py
@@ -32,25 +32,73 @@ LOGGER  : logging.Logger    = logging.getLogger(__name__);
 # -------------------------------------------------------------------------------------------------
 
 class EncoderDecoder(torch.nn.Module):
+    # i'th element is True if the i'th decoder is currently active, otherwise False.
+    # Defaults to an array whose 0 element is True and whose other elements are False (only the 
+    # first decoder is active).
+    Decoder_Active : numpy.ndarray;
+
+    # i,j element holds the weight of the j'th Decoder for the i'th IC. Defaults to an array of 
+    # 1's (all decoders get equal weight).
+    Decoder_Weight : numpy.ndarray;         # shape (n_IC, n_Decoders)
+
+
     def __init__(   self, 
-                    n_IC    : int, 
-                    n_z     : int) -> None:
+                    n_IC        : int, 
+                    n_z         : int,
+                    n_Decoders  : int,
+                    config      : bool) -> None:
         r"""
         Initializes a EncoderDecoder object. A EncoderDecoder object does two things. a) It can 
         encode FOM states (frames) to their latent encodings, and b) it can decode those latent
-        encodings back to the FOM state. An EncoderDecoder object is defined by two variables:
+        encodings back to the FOM state. In general, the encoder accepts n_IC elements of the 
+        FOM space, then encodes them into n_IC elements of the latent space (\\mathbb{R}^{n_z}). 
+        Likewise, the Decoder(s) accept n_IC elements of the latent space and decodes them to 
+        n_IC elements of the FOM space. 
+        
+        EncoderDecoder objects natively support using multiple decoders, which enables things 
+        like multi-stage training (mLaSDI). The actual decode method should return a weighted sum 
+        of these outputs. Thus, an EncoderDecoder object is defined by three variables:
 
             n_IC (the number of initial conditions)
             n_z (the latent space dimension)
+            n_decoders (the number of decoders)
         
-        The encoder must map n_IC elements of the FOM space to n_IC elements of \\mathbb{R}^{n_z}. 
-        The decoder must map n_IC elements of \\mathbb{R}^{n_z} to n_IC elements of the FOM space.
+        The encoder must map n_IC elements of the FOM space to n_IC elements of \mathbb{R}^{n_z}. 
+        Each decoder decoder must map n_IC elements of \mathbb{R}^{n_z} to n_IC elements of the 
+        FOM space, and the "Decode" method must return a weighted sum of the decoder outputs.
 
-        To implement a EncoderDecoder subclass, you must implement the Encode, Decode, forward, 
-        and latent_initial_conditions, and save methods. You should also implement a "load" 
-        function to load the encoded state from a save.
+        To implement a EncoderDecoder subclass, you must implement the Encode, Eval_Decoder, and
+        save/load methods. 
+        
+            - Encode should accept a set of n_IC inputs from the FOM space, encode them, and then 
+            return a tuple housing the encoded inputs. 
+            
+            - Eval_Decoder should accept an integer, i, and a set of n_IC inputs, evaluate the i'th 
+            Decoder on the specified inputs, then return a tuple housing the encodings of the inputs. 
+            The Decode method operates by returning a tuple of tensors, the j'th one of which holds
 
+                \sum_{i'th decoder is active} self.Decoder_Weight(i, j) * self.Eval_Decoder(i, *Z_i)[j]
+            
+            Thus, Eval_Decoder is quite important.
 
+        The base EncoderDecoder class defines the following methods:
+        
+            - latent_initial_conditions: Maps a set of initial conditions for a given set of physics 
+             to the latent space.
+              
+            - Set_Decoder_Active: Modifies the Decoder_Active attribute used by Decoder.
+
+            - Set_Decoder_Weight: Modifies the Decoder_Weight attribute used by Decoder.
+
+            - Decode: Computes and returns a weighted sum of the decoder outputs.
+             
+            - forward: Encodes, then Decodes a set of inputs.
+
+        You are welcome to override any of these in your sub-class, though they should have the 
+        same signatures (inputs and outputs) as the base class (otherwise, something will probably 
+        break elsewhere in the code).
+
+        
         
         -------------------------------------------------------------------------------------------
         Arguments
@@ -63,6 +111,12 @@ class EncoderDecoder(torch.nn.Module):
         n_z : int 
             The latent space dimension.
 
+        n_Decoders : int
+            The number of decoders.
+
+        config: dict
+            The "EncoderDecoder" sub dictionary of the configuration file.
+
 
         -------------------------------------------------------------------------------------------
         Returns
@@ -72,8 +126,12 @@ class EncoderDecoder(torch.nn.Module):
         """
 
         # Checks
-        assert n_IC > 0,    "n_IC = %d; must be positive" % n_IC;
-        assert n_z > 0,     "n_z = %d; must be positive" % n_z;
+        assert isinstance(n_IC, int),       "n_IC must be an int, not %s"       % str(type(n_IC));
+        assert isinstance(n_z, int),        "n_z must be an int, not %s"        % str(type(n_z));
+        assert isinstance(n_Decoders, int), "n_Decoders must be an int, not %s" % str(type(n_Decoders));
+        assert n_IC > 0,                    "n_IC = %d; must be positive"       % n_IC;
+        assert n_z > 0,                     "n_z = %d; must be positive"        % n_z;
+        assert n_Decoders > 0,              "n_Decoders = %d; must be positive" % n_Decoders;
 
         # Run the superclass initializer.
         super().__init__();
@@ -81,13 +139,92 @@ class EncoderDecoder(torch.nn.Module):
         # Store information (for return purposes).
         self.n_IC           : int       = n_IC;
         self.n_z            : int       = n_z;
+        self.n_Decoders     : int       = n_Decoders;
+        self.config         : dict      = config;
 
+        # Set up Decoder_Weight and Decoder_Active.
+        self.Decoder_Active     = numpy.empty((n_Decoders), dtype = numpy.bool);
+        self.Decoder_Active[0]  = True;
+        for i in range(1, n_Decoders):
+            self.Decoder_Active[i]  = False;
+        
+        self.Decoder_Weight     = numpy.ones((n_IC, n_Decoders), dtype = torch.float32);
+    
         # All done!
         return;
 
 
+    
+    # ---------------------------------------------------------------------------------------------
+    # Set_Decoder_Active and Set_Decoder_Weight.
+    # ---------------------------------------------------------------------------------------------
 
-    def Encode(self, X1 : torch.Tensor, Xn_IC : torch.Tensor) -> tuple[torch.Tensor]:
+    def Set_Decoder_Active(self, i_Decoder : int, active : bool) -> None:
+        """
+        Either actives (if active = True) or deactivates (if active = False) the i_Decoder'th 
+        decoder.
+
+
+        -------------------------------------------------------------------------------------------
+        Args:
+
+        i_Decoder : int 
+            The index of the decoder we want to active. Must be in {0, 1, ... , self.n_Decoders - 1}
+        
+        active : bool
+            Either activates (if True) or deactivates (if False) the i_Decoder'th Decoder.
+        """
+
+        # Checks
+        assert isinstance(i_Decoder, int),                              "i_Decoder must be an integer, not %s" % str(type(i_Decoder));
+        assert isinstance(active, bool),                                "active must be a boolean, not %s" % str(type(active));
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}; got %d" % (self.n_Decoders - 1, i_Decoder)
+
+        # Do the thing!
+        self.Decoder_Active[i_Decoder] = active;
+    
+        # Make sure at least one decoder is active
+        assert numpy.sum(self.Decoder_Active) > 0,                      "No decoders active! Can not function!";
+
+
+
+    def Set_Decoder_Weight(self, i_IC : int, i_Decoder : int, weight : float) -> None:
+        """
+        Specifies the weight of the i_Decoder'th decoder for the i_IC'th component (often time 
+        derivative) of the FOM solution. 
+
+        -------------------------------------------------------------------------------------------
+        Args:
+        
+        i_IC : int 
+            The index of the decoder we want to active. Must be in {0, 1, ... , self.n_Decoders - 1}
+        
+        i_Decoder : int 
+            The index of the decoder we want to active. Must be in {0, 1, ... , self.n_Decoders - 1}
+
+        weight : bool
+            Specifies the weight of the i_Decoder'th decoder for the i_IC'th component of the FOM 
+            solution.
+        """
+
+        # Checks
+        assert isinstance(i_IC, int),                                   "i_IC must be an integer, not %s" % str(type(i_IC));
+        assert isinstance(i_Decoder, int),                              "i_Decoder must be an integer, not %s" % str(type(i_Decoder));
+        assert isinstance(weight, float),                               "weight must be a boolean, not %s" % str(type(float));
+        assert (i_IC >= 0) and (i_IC < self.n_Ic - 1),                  "i_IC must be in {0, ... , %d}; got %d" % (self.n_IC - 1, i_IC)
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}; got %d" % (self.n_Decoder - 1, i_Decoder)
+
+        # Do the thing!
+        self.Decoder_Weight[i_IC, i_Decoder] = weight;
+
+
+
+    
+    # ---------------------------------------------------------------------------------------------
+    # Encode, Decode, forward.
+    # ---------------------------------------------------------------------------------------------
+
+    def Encode(self, *Xs : tuple[torch.Tensor]) -> tuple[torch.Tensor]:
         """
         In general, the Encode method should take n_IC positional arguments, each one containing 
         a batch of elements of the FOM space, and map them to n_IC elements of the latent space. 
@@ -99,8 +236,9 @@ class EncoderDecoder(torch.nn.Module):
         Arguments
         -------------------------------------------------------------------------------------------
 
-        X1, ... , Xn_IC : torch.Tensor, shape = (n_inputs, ...)
-            The inputs to be encoded.
+        Xs : self.n_IC torch.Tensor's, each of shape (n_inputs, ...)
+            The inputs to be encoded. The i'th one should hold the i'th component of the FOM 
+            solution that we want to encode.
 
 
         -------------------------------------------------------------------------------------------
@@ -114,19 +252,61 @@ class EncoderDecoder(torch.nn.Module):
         raise RuntimeError("Abstract method EncoderDecoder.Encode!");
 
 
-
-    def Decode(self, Z1 : torch.Tensor, Xn_IC : torch.Tensor) -> tuple[torch.Tensor]:
+    def Eval_Decoder(self, i_Decoder : int, *Zs : tuple[torch.Tensor]) -> tuple[torch.Tensor]:
         """
-        This function should accept n_IC elements of the latent space and map them to n_IC elements 
-        of the FOM space. The output must be a tuple of tensors. The input should be n_IC tensors 
-        (as positional arguments), each with the same shape.
+        Passes the n_IC elements of Zs through the i_Decoder'th decoder, then returns the 
+        corresponding collection of n_IC elements of the FOM space. In general, the Eval_Decoder 
+        method should replace the *Zs argument with n_IC positional arguments, each one containing 
+        a batch of elements of the latent space, and map them to n_IC elements of the FOM space. 
+        The output must be a tuple of tensors.
 
         
         -------------------------------------------------------------------------------------------
         Arguments
         -------------------------------------------------------------------------------------------
 
-        Z1, .. , Zn_IC : torch.Tensor, shape = (n_inputs, ...)
+        i_Decoder : int 
+            The index of the decoder we want to use to compute the decoding. Must be in {0, ... , 
+            self.n_Decoders - 1}
+
+        Zs : self.n_IC torch.Tensor's, each of shape (n_inputs, self.n_Z)
+            The encodings to be decoded. The i'th one should hold the i'th component of the latent 
+            state (often the i'th time derivative of the latent state) that we want to decoder 
+            through the i_Decoder'th decoder. 
+
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        Xs : tuple[torch.Tensor], len = self.n_IC
+            A List of n_IC elements of the FOM space.
+        """ 
+
+        raise RuntimeError("Abstract method EncoderDecoder.Eval_Decoder!");
+
+
+
+
+    def Decode(self, *Zs) -> tuple[torch.Tensor]:
+        """
+        Passes the n_IC elements of Zs through the active decoders, then sums the components 
+        of the resulting tensors according to the decoder weights. Specifically, the i'th 
+        component of the returned tensor holds the following sum:
+
+            \sum_{i'th decoder is active} self.Decoder_Weight(i, j) * self.Eval_Decoder(i, *Z_i)[j]
+        
+        Thus, this function decodes a batch of latent states (each consisting of n_IC components)
+        to a batch of FOM states (again, each one with n_IC components). We literally "decode"
+        the batch of latent states.
+
+
+        
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        Zs : n_IC torch.Tensors, each of shape = (n_inputs, ...)
             The latent states to be decoded.
 
 
@@ -138,36 +318,71 @@ class EncoderDecoder(torch.nn.Module):
             A List of n_IC elements of the FOM space 
         """
 
-        raise RuntimeError("Abstract method EncoderDecoder.Decode!");
+        # Checks.
+        assert len(Zs) == self.n_IC,                    "Decode must receive a tuple of %d Tensors, got a tuple of length %d" % (self.n_IC, len(Zs));
+        for i in range(self.n_IC):
+            assert isinstance(Zs[i], torch.Tensor),     "Each tensor to be Decoded must be a tensor. Component %d is a %s" % (i, str(type(torch.Tensor)));
+            assert len(Zs[i].shape) == 2,               "Each tensor to be Decoded be a tensor of shape (-1, %d), Component %d has shape %s" % (self.n_z, i, str(Zs[i].shape));
+            assert Zs[i].shape[1]   == self.n_z,        "Each tensor to be Decoded be a tensor of shape (-1, %d), Component %d has shape %s" % (self.n_z, i, str(Zs[i].shape));
+
+        # Decode!
+        Xs : tuple[torch.Tensor] = ();
+
+        for i in range(self.n_Decoders):
+            if(self.Decoder_Active[i] == True):
+                ith_Decodings : tuple[torch.Tensor] = self.Eval_Decoder(i_Decoder = i, *Zs);
+
+                for j in range(self.n_IC):
+                    if(len(Xs) < j):
+                        Xs.append(self.Decoder_Weight(j, i)*ith_Decodings[j]);
+                    else:
+                        Xs[j] += self.Decoder_Weight(j, i)*ith_Decodings[j];
+
+        # All done!
+        return Xs;
+                
 
 
-
-    def forward(self, X1 : torch.Tensor, Xn_IC : torch.Tensor) -> tuple[torch.Tensor]:
+    def forward(self, *Xs : tuple[torch.Tensor]) -> tuple[torch.Tensor]:
         """
         This function passes the X's through the encoder, producing a latent state, Z. It then 
-        passes Z through the decoder; hopefully producing a set of vectors that approximates X.
+        passes Z through the decoders; hopefully producing a set of vectors that approximates X.
         
 
         -------------------------------------------------------------------------------------------
         Arguments
         -------------------------------------------------------------------------------------------
 
-        X1, ... , Xn_IC : torch.Tensor, shape = (n_inputs, ...)
-            The inputs to be encoded.
+        Xs : n_IC torch.Tensors, each of shape (n_inputs, ...)
+            The inputs to be encoded and decoded.
 
 
         -------------------------------------------------------------------------------------------
         Returns
         -------------------------------------------------------------------------------------------
 
-        Y : tuple[torch.Tensor], len = self.n_IC
+        Ys : tuple[torch.Tensor], len = self.n_IC
             A self.n_IC element tuple of torch.Tensors in the FOM space holding the image of X 
             under the encoder and decoder. 
         """
 
-        raise RuntimeError("Abstract method EncoderDecoder.forward!");
+        # Checks.
+        assert len(Xs) == self.n_IC,                    "forward must receive a tuple of %d Tensors, got a tuple of length %d" % (self.n_IC, len(Xs));
+        for i in range(self.n_IC):
+            assert isinstance(Xs[i], torch.Tensor),     "Each tensor to be Decoded must be a tensor. Component %d is a %s" % (i, str(type(torch.Tensor)));
+
+        # Encode and Decode!
+        Zs : tuple[torch.Tensor] = self.Encode(*Xs);
+        Ys : tuple[torch.Tensor] = self.Decode(*Zs);
+
+        # All done!
+        return Ys;
 
 
+
+    # ---------------------------------------------------------------------------------------------
+    # latent_initial_conditions
+    # ---------------------------------------------------------------------------------------------
 
     def latent_initial_conditions(  self,
                                     param_grid     : numpy.ndarray, 

--- a/src/EncoderDecoder/EncoderDecoder.py
+++ b/src/EncoderDecoder/EncoderDecoder.py
@@ -46,7 +46,7 @@ class EncoderDecoder(torch.nn.Module):
                     n_IC        : int, 
                     n_z         : int,
                     n_Decoders  : int,
-                    config      : bool) -> None:
+                    config      : dict) -> None:
         r"""
         Initializes a EncoderDecoder object. A EncoderDecoder object does two things. a) It can 
         encode FOM states (frames) to their latent encodings, and b) it can decode those latent
@@ -77,7 +77,7 @@ class EncoderDecoder(torch.nn.Module):
             Decoder on the specified inputs, then return a tuple housing the encodings of the inputs. 
             The Decode method operates by returning a tuple of tensors, the j'th one of which holds
 
-                \sum_{i'th decoder is active} self.Decoder_Weight(i, j) * self.Eval_Decoder(i, *Z_i)[j]
+                \sum_{d'th decoder is active} Decoder_Weight[j, d] * Eval_Decoder(d, *Zs)[j]
             
             Thus, Eval_Decoder is quite important.
 
@@ -143,12 +143,12 @@ class EncoderDecoder(torch.nn.Module):
         self.config         : dict      = config;
 
         # Set up Decoder_Weight and Decoder_Active.
-        self.Decoder_Active     = numpy.empty((n_Decoders), dtype = numpy.bool);
+        self.Decoder_Active     = numpy.empty((n_Decoders), dtype = numpy.bool_);
         self.Decoder_Active[0]  = True;
         for i in range(1, n_Decoders):
             self.Decoder_Active[i]  = False;
         
-        self.Decoder_Weight     = numpy.ones((n_IC, n_Decoders), dtype = torch.float32);
+        self.Decoder_Weight     = numpy.ones((n_IC, n_Decoders), dtype = numpy.float32);
     
         # All done!
         return;
@@ -178,7 +178,7 @@ class EncoderDecoder(torch.nn.Module):
         # Checks
         assert isinstance(i_Decoder, int),                              "i_Decoder must be an integer, not %s" % str(type(i_Decoder));
         assert isinstance(active, bool),                                "active must be a boolean, not %s" % str(type(active));
-        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}; got %d" % (self.n_Decoders - 1, i_Decoder)
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders),      "i_Decoder must be in {0, ... , %d}; got %d" % (self.n_Decoders - 1, i_Decoder)
 
         # Do the thing!
         self.Decoder_Active[i_Decoder] = active;
@@ -202,7 +202,7 @@ class EncoderDecoder(torch.nn.Module):
         i_Decoder : int 
             The index of the decoder we want to active. Must be in {0, 1, ... , self.n_Decoders - 1}
 
-        weight : bool
+        weight : float | int
             Specifies the weight of the i_Decoder'th decoder for the i_IC'th component of the FOM 
             solution.
         """
@@ -210,9 +210,9 @@ class EncoderDecoder(torch.nn.Module):
         # Checks
         assert isinstance(i_IC, int),                                   "i_IC must be an integer, not %s" % str(type(i_IC));
         assert isinstance(i_Decoder, int),                              "i_Decoder must be an integer, not %s" % str(type(i_Decoder));
-        assert isinstance(weight, float),                               "weight must be a boolean, not %s" % str(type(float));
-        assert (i_IC >= 0) and (i_IC < self.n_Ic - 1),                  "i_IC must be in {0, ... , %d}; got %d" % (self.n_IC - 1, i_IC)
-        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders - 1),  "i_Decoder must be in {0, ... , %d}; got %d" % (self.n_Decoder - 1, i_Decoder)
+        assert isinstance(weight, float) or isinstance(weight, int),    "weight must be numeric, not %s" % str(type(float));
+        assert (i_IC >= 0) and (i_IC < self.n_IC),                      "i_IC must be in {0, ... , %d}; got %d" % (self.n_IC - 1, i_IC)
+        assert (i_Decoder >= 0) and (i_Decoder < self.n_Decoders),      "i_Decoder must be in {0, ... , %d}; got %d" % (self.n_Decoders - 1, i_Decoder)
 
         # Do the thing!
         self.Decoder_Weight[i_IC, i_Decoder] = weight;
@@ -289,12 +289,12 @@ class EncoderDecoder(torch.nn.Module):
 
 
     def Decode(self, *Zs) -> tuple[torch.Tensor]:
-        """
+        r"""
         Passes the n_IC elements of Zs through the active decoders, then sums the components 
-        of the resulting tensors according to the decoder weights. Specifically, the i'th 
+        of the resulting tensors according to the decoder weights. Specifically, the j'th 
         component of the returned tensor holds the following sum:
 
-            \sum_{i'th decoder is active} self.Decoder_Weight(i, j) * self.Eval_Decoder(i, *Z_i)[j]
+            \sum_{d'th decoder is active} Decoder_Weight[j, d] * Eval_Decoder(d, *Z)[j]
         
         Thus, this function decodes a batch of latent states (each consisting of n_IC components)
         to a batch of FOM states (again, each one with n_IC components). We literally "decode"
@@ -326,20 +326,23 @@ class EncoderDecoder(torch.nn.Module):
             assert Zs[i].shape[1]   == self.n_z,        "Each tensor to be Decoded be a tensor of shape (-1, %d), Component %d has shape %s" % (self.n_z, i, str(Zs[i].shape));
 
         # Decode!
-        Xs : tuple[torch.Tensor] = ();
+        Xs : list[torch.Tensor | None] = [None]*self.n_IC;
 
-        for i in range(self.n_Decoders):
-            if(self.Decoder_Active[i] == True):
-                ith_Decodings : tuple[torch.Tensor] = self.Eval_Decoder(i_Decoder = i, *Zs);
+        for d in range(self.n_Decoders):
+            if(self.Decoder_Active[d] == True):
+                dth_Decodings : tuple[torch.Tensor] = self.Eval_Decoder(d, *Zs);
 
                 for j in range(self.n_IC):
-                    if(len(Xs) < j):
-                        Xs.append(self.Decoder_Weight(j, i)*ith_Decodings[j]);
+                    w       = float(self.Decoder_Weight[j, d])
+                    term    = w* dth_Decodings[j];
+                    
+                    if Xs[j] is None:
+                        Xs[j] = term;
                     else:
-                        Xs[j] += self.Decoder_Weight(j, i)*ith_Decodings[j];
+                        Xs[j] = Xs[j] + term;
 
         # All done!
-        return Xs;
+        return tuple(Xs);
                 
 
 
@@ -472,6 +475,10 @@ class EncoderDecoder(torch.nn.Module):
 
 
 
+    # ---------------------------------------------------------------------------------------------
+    # Save, Load
+    # ---------------------------------------------------------------------------------------------
+
     def export(self) -> dict:
         """
         -------------------------------------------------------------------------------------------
@@ -481,6 +488,28 @@ class EncoderDecoder(torch.nn.Module):
         This function extracts everything we need to recreate self from scratch.
         """
 
-        raise RuntimeError("Abstract method EncoderDecoder.export!");
+        dict_ =     {   "Decoder_Weight"    : self.Decoder_Weight,
+                        "Decoder_Active"    : self.Decoder_Active,
+                        "n_z"               : self.n_z,
+                        "n_IC"              : self.n_IC,
+                        "n_Decoders"        : self.n_Decoders };
+    
+        return dict_;
+
+
+    
+    def load(self, dict_):
+        """
+        dict_: Should be the dict returned by the export method.
+        """
+        
+        # Load the decoder weights/which ones are active.
+        self.Decoder_Weight     = dict_['Decoder_Weight'];
+        self.Decoder_Active     = dict_['Decoder_Active'];
+        
+        # Make sure n_z, n_IC, and n_Decoders match what we just set up.
+        assert self.n_z         == dict_['n_z'];
+        assert self.n_IC        == dict_['n_IC'];
+        assert self.n_Decoders  == dict_['n_Decoders'];
 
 

--- a/src/Initialize.py
+++ b/src/Initialize.py
@@ -270,8 +270,7 @@ def Initialize_Encoder_Decoder(physics : Physics, config : dict) -> EncoderDecod
         This encoder_decoder should have a latent space of some form. We learn a set of dynamics to 
         describe how this latent space evolves over time. 
     """
-
-
+    
     # First, determine what encoder_decoder we are using in the latent dynamics. Make sure the user 
     # included all the information that is necessary to initialize the corresponding dynamics.
     encoder_decoder_type : str = config['EncoderDecoder']['type'];
@@ -279,97 +278,8 @@ def Initialize_Encoder_Decoder(physics : Physics, config : dict) -> EncoderDecod
     assert(encoder_decoder_type in encoder_decoder_dict);
     LOGGER.info("Initializing EncoderDecoder (%s)" % encoder_decoder_type);
 
-    # Autoencoder, autoencoder pair case.
-    if(encoder_decoder_type == "ae" or encoder_decoder_type == "pair" or encoder_decoder_type == "autoencoder" or encoder_decoder_type == "autoencoder_pair"):
-        # Next, fetch the hidden widths and latent dimension (n_z). 
-        encoder_decoder_config  : dict              = config['EncoderDecoder'][encoder_decoder_type];
-        hidden_widths           : list[int]         = encoder_decoder_config['hidden_widths'];
-        n_z                     : int               = encoder_decoder_config['latent_dimension'];
-
-        # Fetch the activations. This can either be a string or a list of strings. If it's 
-        # a string, then we use that activation for all layers.
-        n_hidden_layers     : int               = len(hidden_widths);
-        if(isinstance(encoder_decoder_config['activations'], str)):
-            activations         : list[str]     = [encoder_decoder_config['activations']] * n_hidden_layers;   # The final layer has no activation.
-        elif(isinstance(encoder_decoder_config['activations'], list)):
-            activations         : list[str]     = encoder_decoder_config['activations'];
-            assert(len(activations) == n_hidden_layers);
-        else:
-            raise ValueError("Activations must be a string or a list of strings.");
-
-        # Now build the widths attribute + fetch Frame_Shape from physics.
-        Frame_Shape         : list[int]         = physics.Frame_Shape;
-        space_dim           : int               = numpy.prod(Frame_Shape).item();
-        widths              : list[int]         = [space_dim] + hidden_widths + [n_z];
-
-        # Now build the encoder_decoder!
-        encoder_decoder : EncoderDecoder        = encoder_decoder_dict[encoder_decoder_type](
-                                                        widths          = widths, 
-                                                        activations     = activations, 
-                                                        reshape_shape   = Frame_Shape);
-
-        # All done!
-        return encoder_decoder;
-
-
-    # Convolutional autoencoder case.
-    elif(encoder_decoder_type == "cnn_3d" or encoder_decoder_type == "cnn_3d_ae" or encoder_decoder_type == "cnn_3d_autoencoder"):
-        encoder_decoder_config  : dict              = config['EncoderDecoder'][encoder_decoder_type];
-
-        # FC configuration (analogous to the AE's hidden_widths/activations).
-        hidden_widths_fc        : list[int]         = encoder_decoder_config.get('hidden_widths_fc', encoder_decoder_config.get('hidden_widths'));
-        n_z                     : int               = encoder_decoder_config['latent_dimension'];
-
-        # FC activations can either be a string or a list of strings.
-        n_hidden_layers         : int               = len(hidden_widths_fc);
-        act_cfg = encoder_decoder_config.get('activations_fc', encoder_decoder_config.get('activations'));
-        if(isinstance(act_cfg, str)):
-            activations_fc      : list[str]        = [act_cfg] * n_hidden_layers;
-        elif(isinstance(act_cfg, list)):
-            activations_fc      : list[str]        = act_cfg;
-            assert(len(activations_fc) == n_hidden_layers);
-        else:
-            raise ValueError("activations_fc must be a string or a list of strings.");
-
-        # Conv configuration.
-        conv_channels       : list[int]         = encoder_decoder_config['conv_channels'];
-        conv_kernel_sizes   = encoder_decoder_config.get('conv_kernel_sizes', 3);
-        conv_strides        = encoder_decoder_config.get('conv_strides', 2);
-        conv_paddings       = encoder_decoder_config.get('conv_paddings', 1);
-
-        # Per-layer conv activations. This can be a string (use same activation for all conv layers)
-        # or a list of strings of length len(conv_channels) - 1.
-        conv_act_cfg = encoder_decoder_config.get('conv_activations', 'relu');
-        if(isinstance(conv_act_cfg, str)):
-            conv_activations : list[str] = [conv_act_cfg] * (len(conv_channels) - 1);
-        elif(isinstance(conv_act_cfg, list)):
-            conv_activations = conv_act_cfg;
-            assert(len(conv_activations) == len(conv_channels) - 1);
-        else:
-            raise ValueError("conv_activations must be a string or a list of strings.");
-
-        # Fetch Frame_Shape from physics (must be 3D for Conv3d).
-        Frame_Shape         : list[int]         = physics.Frame_Shape;
-        assert(len(Frame_Shape) == 4), "physics.Frame_Shape = %s; Conv_Autoencoder requires a 3D spatial shape" % str(Frame_Shape);
-        C               : int       = int(Frame_Shape[0]);
-        reshape_shape   : list[int] = [int(x) for x in Frame_Shape[1:]];
-        assert conv_channels[0] == C, "conv_chanels[0] = %d, but the data has %d channels. These must match" % (conv_channels[0], C);
-
-        encoder_decoder     : EncoderDecoder    = encoder_decoder_dict[encoder_decoder_type](
-                                                        reshape_shape        = reshape_shape,
-                                                        hidden_widths_fc     = hidden_widths_fc,
-                                                        activations_fc       = activations_fc,
-                                                        latent_dimension     = n_z,
-                                                        conv_channels        = conv_channels,
-                                                        conv_kernel_sizes    = conv_kernel_sizes,
-                                                        conv_strides         = conv_strides,
-                                                        conv_paddings        = conv_paddings,
-                                                        conv_activations     = conv_activations);
-
-        return encoder_decoder;
-
-    else:
-        raise ValueError("EncoderDecoder type %s not supported." % encoder_decoder_type);
+    encoder_decoder_dict[encoder_decoder_type]( Frame_Shape = physics.Frame_Shape,
+                                                config      = config['EncoderDecoder']);
 
 
 

--- a/src/Initialize.py
+++ b/src/Initialize.py
@@ -278,8 +278,11 @@ def Initialize_Encoder_Decoder(physics : Physics, config : dict) -> EncoderDecod
     assert(encoder_decoder_type in encoder_decoder_dict);
     LOGGER.info("Initializing EncoderDecoder (%s)" % encoder_decoder_type);
 
-    encoder_decoder_dict[encoder_decoder_type]( Frame_Shape = physics.Frame_Shape,
+    encoder_decoder = encoder_decoder_dict[encoder_decoder_type]( 
+                                                Frame_Shape = physics.Frame_Shape,
                                                 config      = config['EncoderDecoder']);
+
+    return encoder_decoder;
 
 
 

--- a/src/Sample/Sampler.py
+++ b/src/Sample/Sampler.py
@@ -288,7 +288,7 @@ class Sampler:
                             break;
                     
                     if test_idx is not None:
-                        # New coefficients will be untrained, so we should intialize them using least-squares fit.
+                        # New coefficients will be untrained, so we should initialize them using least-squares fit.
                         U_new_i = new_U_Train[i];  # List of tensors (one per IC)
                         t_new_i = new_t_Train[i];  # Time grid tensor
                         


### PR DESCRIPTION
Added multi-staging support to HLaSDI.

To make this work, I revised the way that the EncoderDecoder model is defined. Now, the Decoder actually is a weighted linear combination of sub-decoders (each one is a map from the latent space to the FOM space).

There are new methods to determine which of these decoders are active (and will show up in the final linear combination) and the weights (for the active decoders). By changing these during training, the training process can implement a multi-stage approach (first enable only the first model with a weight of one, with all other models disabled... train that one... then disable the first decoder, enable the second one with a weight of one and train it to predict the residuals left over by the first decoder and so on). In other words, HLaSDI can now implement mLaSDI style training. 

See the updated EncoderDecoder class for details.